### PR TITLE
CSS tweaks to make Firefox look like Chrome

### DIFF
--- a/src/components/forms/fields/Dropdown/Dropdown.scss
+++ b/src/components/forms/fields/Dropdown/Dropdown.scss
@@ -26,7 +26,6 @@
 
   .Select-value {
     border-radius: 2px;
-    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.12), 0 2px 0 0 #b8c2e3;
     color: $accent-color;
 
     .Select-value-icon {

--- a/src/components/forms/fields/PlatformDropdown/PlatformDropdown.scss
+++ b/src/components/forms/fields/PlatformDropdown/PlatformDropdown.scss
@@ -32,6 +32,7 @@
 }
 
 .platform-dropdown__text {
+  background-color: transparent;
   border: 0;
   color: $accent-color;
   cursor: pointer;


### PR DESCRIPTION
* Remove box-shadow that's only visible on firefox
* Remove background-color from text that makes platform version look
  strange

Before:
![screenshot-2018-1-22 osquery schema 1](https://user-images.githubusercontent.com/342554/35237963-19819b5c-ff7a-11e7-8654-285facd2f113.png)

After:
![screenshot-2018-1-22 osquery schema](https://user-images.githubusercontent.com/342554/35237975-24c2577c-ff7a-11e7-8c41-b178f3e26808.png)
