### PR TITLE
Prevent sidebar scroll chaining

### DIFF
--- a/src/components/SchemaTOC/SchemaTOC.js
+++ b/src/components/SchemaTOC/SchemaTOC.js
@@ -18,12 +18,25 @@ class SchemaTOC extends Component {
     return () => onEntryClick(entry)
   }
 
+  preventBodyScroll = () => document.body.classList.add('noscroll')
+  allowBodyScroll = () => document.body.classList.remove('noscroll')
+
+  componentDidMount() {
+    this.toc.addEventListener('mouseenter', this.preventBodyScroll)
+    this.toc.addEventListener('mouseleave', this.allowBodyScroll)
+  }
+
+  componentWillUnmount() {
+    this.toc.removeEventListener('mouseenter', this.preventBodyScroll)
+    this.toc.removeEventListener('mouseleave', this.allowBodyScroll)
+  }
+
   render() {
     const { handleClick } = this
     const { activeEntry, entries } = this.props
 
     return (
-      <ol className={baseClass} id={`${baseClass}__list`}>
+      <ol className={baseClass} id={`${baseClass}__list`} ref={el => (this.toc = el)}>
         {entries &&
           entries.map((entry, index) => {
             return (

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,8 @@ body {
   margin: 0;
   min-height: 100vh;
   padding: 0; }
+  body.noscroll {
+    overflow: hidden; }
 
 #root {
   min-height: 100vh; }

--- a/src/index.scss
+++ b/src/index.scss
@@ -5,6 +5,10 @@ body {
   margin: 0;
   min-height: 100vh;
   padding: 0;
+
+  &.noscroll {
+    overflow: hidden;
+  }
 }
 
 #root {

--- a/src/pages/Schema/Schema.js
+++ b/src/pages/Schema/Schema.js
@@ -145,9 +145,10 @@ class Schema extends Component {
     const { overrideScroll } = this.state
     const windowScroll = global.window.scrollY
 
-    const activeTable = tablePositions.find(table => {
-      return table.offset > windowScroll
-    }) || tablePositions[tablePositions.length -1].name
+    const activeTable =
+      tablePositions.find(table => {
+        return table.offset > windowScroll
+      }) || tablePositions[tablePositions.length - 1].name
 
     if (!overrideScroll) {
       if (activeTable) {


### PR DESCRIPTION
This prevents the "scroll chaining" behavior when scrolling content
which scrolls outer content once the inner content can no longer be
scrolled. This was causing issues with the schema pages sidebar since
scroll to the top would scroll `body` and immediately update the sidebar
scroll.

This resolves the issue by setting `overflow: hidden;` on `body` when
the users mouse enters the sidebar and removes it when the mouse leaves.
Because body is unscrollable the scroll chaining "stops" at the sidebar.