### PR TITLE
Give GitHub an uppercase H

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -55,7 +55,7 @@ const Footer = () => {
 
         <ul>
           <li className={`${baseClass}__li`}>
-            <a href="https://github.com/facebook/osquery">View the code on Github</a>
+            <a href="https://github.com/facebook/osquery">View the code on GitHub</a>
           </li>
         </ul>
       </section>

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -459,7 +459,7 @@ class Home extends Component {
               href="https://github.com/facebook/osquery"
               icon={<Icon name="octocat" />}
             >
-              <span>View the Github Project</span>
+              <span>View the GitHub Project</span>
             </ProminentCta>
           </div>
         </section>

--- a/stories/index.js
+++ b/stories/index.js
@@ -216,7 +216,7 @@ storiesOf('ProminentCta', module)
   ))
   .add('Github', () => (
     <ProminentCta icon={<Icon name="octocat" />}>
-      <a href="#">View the Github Project</a>
+      <a href="#">View the GitHub Project</a>
     </ProminentCta>
   ))
 


### PR DESCRIPTION
<img width="1194" alt="screen shot 2018-01-28 at 5 55 21 pm" src="https://user-images.githubusercontent.com/121322/35490454-8c9a1b08-0454-11e8-838e-b1edb6f30f03.png">

Hi! The new website is gorgeous! I noticed that GitHub was spelled with a lowercase `h` is a few places; fix attached for your consideration 🤘 