### PR TITLE
Package 2.11.2 fix

### DIFF
--- a/src/data/osquery_package_versions/2.11.2.json
+++ b/src/data/osquery_package_versions/2.11.2.json
@@ -25,6 +25,12 @@
         "package": "osquery_2.11.2_1.linux.amd64.deb",
         "content": "cf140838778e0c32344a6aeb3f45d2ae2cd44f2e7ec9acb19fc99ff883d52ef5",
         "url": "https://pkg.osquery.io/deb/osquery_2.11.2_1.linux.amd64.deb"
+      },
+      {
+        "type": "Windows",
+        "package": "osquery-2.11.2.msi",
+        "content": "dc1ab769c5960de24824184da63edcdda90b9bceda41d1fc8717bbfa8ab1d4bd",
+        "url": "https://pkg.osquery.io/windows/osquery-2.11.2.msi"
       }
     ],
     "debug": [

--- a/src/data/osquery_schema_versions/2.11.2.json
+++ b/src/data/osquery_schema_versions/2.11.2.json
@@ -1,57 +1,15489 @@
-{
-  "version": "2.11.2",
-  "downloads": {
-    "official": [
+[
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"acpi_tables",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/acpi_tables.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
       {
-        "type": "macOS",
-        "package": "osquery-2.11.2.pkg",
-        "content": "c28e561c9626e5fa2e7be06df73a63a96f1ca76c0e591ab492d3354745713476",
-        "url": "https://pkg.osquery.io/darwin/osquery-2.11.2.pkg"
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"ACPI table name"
       },
       {
-        "type": "Linux",
-        "package": "osquery-2.11.2_1.linux_x86_64.tar.gz",
-        "content": "6b9f032bf04a0a938c4cd2a7f24f0f4fef1aca8593661f3801822760b178fdbd",
-        "url": "https://pkg.osquery.io/linux/osquery-2.11.2_1.linux_x86_64.tar.gz"
+        "index":false,
+        "name":"size",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Size of compiled table data"
       },
       {
-        "type": "RPM",
-        "package": "osquery-2.11.2-1.linux.x86_64.rpm",
-        "content": "e7dd21d76b33b4ccad5280a8685f71a557bc008c2aaa41cfa696aa1d537bedad",
-        "url": "https://pkg.osquery.io/rpm/osquery-2.11.2-1.linux.x86_64.rpm"
-      },
-      {
-        "type": "Debian",
-        "package": "osquery_2.11.2_1.linux.amd64.deb",
-        "content": "cf140838778e0c32344a6aeb3f45d2ae2cd44f2e7ec9acb19fc99ff883d52ef5",
-        "url": "https://pkg.osquery.io/deb/osquery_2.11.2_1.linux.amd64.deb"
-      },
-      {
-        "type": "Windows",
-        "package": "osquery-2.11.2.msi",
-        "content": "dc1ab769c5960de24824184da63edcdda90b9bceda41d1fc8717bbfa8ab1d4bd",
-        "url": "https://pkg.osquery.io/windows/osquery-2.11.2.msi"
+        "index":false,
+        "name":"md5",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"MD5 hash of table content"
       }
     ],
-    "debug": [
+    "description":"Firmware ACPI functional table common metadata and content."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"ad_config",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/ad_config.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
       {
-        "type": "macOS",
-        "package": "osquery-debug-2.11.2.pkg",
-        "content": "bb30981eabb5be24bc06a95aa91c2afb9cbca8deaf00d8d83810bfe8107cad6a",
-        "url": "https://pkg.osquery.io/darwin/osquery-debug-2.11.2.pkg"
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The OS X-specific configuration name"
       },
       {
-        "type": "RPM",
-        "package": "osquery-debuginfo-2.11.2-1.linux.x86_64.rpm",
-        "content": "4183781d064c970d3990aaaf7c4a51831a361b3ce4ed90d12730965901e9f73e",
-        "url": "https://pkg.osquery.io/rpm/osquery-debuginfo-2.11.2-1.linux.x86_64.rpm"
+        "index":false,
+        "name":"domain",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Active Directory trust domain"
       },
       {
-        "type": "Debian",
-        "package": "osquery-dbg_2.11.2_1.linux.amd64.deb",
-        "content": "8dba185c4a42849ec379b7acec9f2b6db3ca7b61e1627d5647d41a3d9834bc5c",
-        "url": "https://pkg.osquery.io/deb/osquery-dbg_2.11.2_1.linux.amd64.deb"
+        "index":false,
+        "name":"option",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Canonical name of option"
+      },
+      {
+        "index":false,
+        "name":"value",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Variable typed option value"
       }
-    ]
+    ],
+    "description":"OS X Active Directory configuration."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"alf",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/alf.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"allow_signed_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If allow signed mode is enabled else 0"
+      },
+      {
+        "index":false,
+        "name":"firewall_unload",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If firewall unloading enabled else 0"
+      },
+      {
+        "index":false,
+        "name":"global_state",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If the firewall start by default else 0"
+      },
+      {
+        "index":false,
+        "name":"logging_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If logging mode is enabled else 0"
+      },
+      {
+        "index":false,
+        "name":"logging_option",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Firewall logging option"
+      },
+      {
+        "index":false,
+        "name":"stealth_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If stealth mode is enabled else 0"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Application Layer Firewall version"
+      }
+    ],
+    "description":"OS X application layer firewall (ALF) service details."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"alf_exceptions",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/alf_exceptions.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to the executable that is excepted"
+      },
+      {
+        "index":false,
+        "name":"state",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Firewall exception state"
+      }
+    ],
+    "description":"OS X application layer firewall (ALF) service exceptions."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"alf_explicit_auths",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/alf_explicit_auths.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"process",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Process name explicitly allowed"
+      }
+    ],
+    "description":"ALF services explicitly allowed to perform networking."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"alf_services",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/alf_services.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"service",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Firewalled service name"
+      },
+      {
+        "index":false,
+        "name":"process",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Process name"
+      },
+      {
+        "index":false,
+        "name":"state",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Firewall service state"
+      }
+    ],
+    "description":"OS X application layer firewall (Firewall) services."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"app_schemes",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/app_schemes.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"scheme",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the scheme/protocol"
+      },
+      {
+        "index":false,
+        "name":"handler",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Application label for the handler"
+      },
+      {
+        "index":false,
+        "name":"enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if this handler is the OS default, else 0"
+      },
+      {
+        "index":false,
+        "name":"external",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if this handler does NOT exist on OS X by default, else 0"
+      },
+      {
+        "index":false,
+        "name":"protected",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if this handler is protected (reserved) by OS X, else 0"
+      }
+    ],
+    "description":"OS X application schemes and handlers (e.g., http, file, mailto)."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"appcompat_shims",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/windows/appcompat_shims.table",
+    "platforms":[
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"executable",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the executable that is being shimmed. This is pulled from the registry."
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"This is the path to the SDB database."
+      },
+      {
+        "index":false,
+        "name":"description",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Description of the SDB."
+      },
+      {
+        "index":false,
+        "name":"install_time",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Install time of the SDB"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Type of the SDB database."
+      },
+      {
+        "index":false,
+        "name":"sdb_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Unique GUID of the SDB."
+      }
+    ],
+    "description":"Application Compatibility shims are a way to persist malware. This table presents the AppCompat Shim information from the registry in a nice format. See http://files.brucon.org/2015/Tomczak_and_Ballenthin_Shims_for_the_Win.pdf for more details."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"apps",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/apps.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the Name.app folder"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Absolute and full Name.app path"
+      },
+      {
+        "index":false,
+        "name":"bundle_executable",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Info properties CFBundleExecutable label"
+      },
+      {
+        "index":false,
+        "name":"bundle_identifier",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Info properties CFBundleIdentifier label"
+      },
+      {
+        "index":false,
+        "name":"bundle_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Info properties CFBundleName label"
+      },
+      {
+        "index":false,
+        "name":"bundle_short_version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Info properties CFBundleShortVersionString label"
+      },
+      {
+        "index":false,
+        "name":"bundle_version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Info properties CFBundleVersion label"
+      },
+      {
+        "index":false,
+        "name":"bundle_package_type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Info properties CFBundlePackageType label"
+      },
+      {
+        "index":false,
+        "name":"environment",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Application-set environment variables"
+      },
+      {
+        "index":false,
+        "name":"element",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Does the app identify as a background agent"
+      },
+      {
+        "index":false,
+        "name":"compiler",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Info properties DTCompiler label"
+      },
+      {
+        "index":false,
+        "name":"development_region",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Info properties CFBundleDevelopmentRegion label"
+      },
+      {
+        "index":false,
+        "name":"display_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Info properties CFBundleDisplayName label"
+      },
+      {
+        "index":false,
+        "name":"info_string",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Info properties CFBundleGetInfoString label"
+      },
+      {
+        "index":false,
+        "name":"minimum_system_version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Minimum version of OS X required for the app to run"
+      },
+      {
+        "index":false,
+        "name":"category",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The UTI that categorizes the app for the App Store"
+      },
+      {
+        "index":false,
+        "name":"applescript_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Info properties NSAppleScriptEnabled label"
+      },
+      {
+        "index":false,
+        "name":"copyright",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Info properties NSHumanReadableCopyright label"
+      },
+      {
+        "index":false,
+        "name":"last_opened_time",
+        "required":false,
+        "hidden":false,
+        "type":"double",
+        "description":"The time that the app was last used"
+      }
+    ],
+    "description":"OS X applications installed in known search paths (e.g., /Applications)."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"apt_sources",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/linux/apt_sources.table",
+    "platforms":[
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Repository name"
+      },
+      {
+        "index":false,
+        "name":"base_uri",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Repository base URI"
+      },
+      {
+        "index":false,
+        "name":"package_cache_file",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Repository cache file"
+      },
+      {
+        "index":false,
+        "name":"release",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Release name"
+      },
+      {
+        "index":false,
+        "name":"component",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Repository component"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Repository source version"
+      },
+      {
+        "index":false,
+        "name":"maintainer",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Repository maintainer"
+      },
+      {
+        "index":false,
+        "name":"site",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Repository site"
+      }
+    ],
+    "description":"Current\u00a0list of APT repositories or software channels."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"arp_cache",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/arp_cache.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"address",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"IPv4 address target"
+      },
+      {
+        "index":false,
+        "name":"mac",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"MAC address of broadcasted address"
+      },
+      {
+        "index":false,
+        "name":"interface",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Interface of the network for the MAC"
+      },
+      {
+        "index":false,
+        "name":"permanent",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"1 for true, 0 for false"
+      }
+    ],
+    "description":"Address resolution cache, both static and dynamic (from ARP, NDP)."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"asl",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/asl.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"time",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Unix timestamp.  Set automatically"
+      },
+      {
+        "index":false,
+        "name":"time_nano_sec",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Nanosecond time."
+      },
+      {
+        "index":false,
+        "name":"host",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Sender's address (set by the server)."
+      },
+      {
+        "index":false,
+        "name":"sender",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Sender's identification string.  Default is process name."
+      },
+      {
+        "index":false,
+        "name":"facility",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Sender's facility.  Default is 'user'."
+      },
+      {
+        "index":false,
+        "name":"pid",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Sending process ID encoded as a string.  Set automatically."
+      },
+      {
+        "index":false,
+        "name":"gid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"GID that sent the log message (set by the server)."
+      },
+      {
+        "index":false,
+        "name":"uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"UID that sent the log message (set by the server)."
+      },
+      {
+        "index":false,
+        "name":"level",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Log level number.  See levels in asl.h."
+      },
+      {
+        "index":false,
+        "name":"message",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Message text."
+      },
+      {
+        "index":false,
+        "name":"ref_pid",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Reference PID for messages proxied by launchd"
+      },
+      {
+        "index":false,
+        "name":"ref_proc",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Reference process for messages proxied by launchd"
+      },
+      {
+        "index":false,
+        "name":"extra",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Extra columns, in JSON format. Queries against this column are performed entirely in SQLite, so do not benefit from efficient querying via asl.h."
+      }
+    ],
+    "description":"Queries the Apple System Log data structure for system events."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"augeas",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/augeas.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"node",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The node path of the configuration item"
+      },
+      {
+        "index":false,
+        "name":"value",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The value of the configuration item"
+      },
+      {
+        "index":false,
+        "name":"label",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The label of the configuration item"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The path to the configuration file"
+      }
+    ],
+    "description":"Configuration files parsed by augeas."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"authenticode",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/windows/authenticode.table",
+    "platforms":[
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"path",
+        "required":true,
+        "hidden":false,
+        "type":"text",
+        "description":"Must provide a path or directory"
+      },
+      {
+        "index":false,
+        "name":"original_program_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The original program name that the publisher has signed"
+      },
+      {
+        "index":false,
+        "name":"serial_number",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The certificate serial number"
+      },
+      {
+        "index":false,
+        "name":"issuer_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The certificate issuer name"
+      },
+      {
+        "index":false,
+        "name":"subject_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The certificate subject name"
+      },
+      {
+        "index":false,
+        "name":"result",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The signature check result"
+      }
+    ],
+    "description":"File (executable, bundle, installer, disk) code signing status."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"authorization_mechanisms",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/authorization_mechanisms.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"label",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Label of the authorization right"
+      },
+      {
+        "index":false,
+        "name":"plugin",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Authorization plugin name"
+      },
+      {
+        "index":false,
+        "name":"mechanism",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the mechanism that will be called"
+      },
+      {
+        "index":false,
+        "name":"privileged",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"If privileged it will run as root, else as an anonymous user"
+      },
+      {
+        "index":false,
+        "name":"entry",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The whole string entry"
+      }
+    ],
+    "description":"OS X Authorization mechanisms database."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"authorizations",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/authorizations.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"label",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Item name, usually in reverse domain format"
+      },
+      {
+        "index":false,
+        "name":"modified",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Label top-level key"
+      },
+      {
+        "index":false,
+        "name":"allow_root",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Label top-level key"
+      },
+      {
+        "index":false,
+        "name":"timeout",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Label top-level key"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Label top-level key"
+      },
+      {
+        "index":false,
+        "name":"tries",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Label top-level key"
+      },
+      {
+        "index":false,
+        "name":"authenticate_user",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Label top-level key"
+      },
+      {
+        "index":false,
+        "name":"shared",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Label top-level key"
+      },
+      {
+        "index":false,
+        "name":"comment",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Label top-level key"
+      },
+      {
+        "index":false,
+        "name":"created",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Label top-level key"
+      },
+      {
+        "index":false,
+        "name":"class",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Label top-level key"
+      },
+      {
+        "index":false,
+        "name":"session_owner",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Label top-level key"
+      }
+    ],
+    "description":"OS X Authorization rights database."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"authorized_keys",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/authorized_keys.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The local owner of authorized_keys file"
+      },
+      {
+        "index":false,
+        "name":"algorithm",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"algorithim of key"
+      },
+      {
+        "index":false,
+        "name":"key",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"parsed authorized keys line"
+      },
+      {
+        "index":false,
+        "name":"key_file",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to the authorized_keys file"
+      }
+    ],
+    "description":"A line-delimited authorized_keys table."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"autoexec",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/windows/autoexec.table",
+    "platforms":[
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to the executable"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the program"
+      },
+      {
+        "index":false,
+        "name":"source",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Source table of the autoexec item"
+      }
+    ],
+    "description":"Aggregate of executables that will automatically execute on the target machine. This is an amalgamation of other tables like services, scheduled tasks, startup_items and more."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"block_devices",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/block_devices.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Block device name"
+      },
+      {
+        "index":false,
+        "name":"parent",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Block device parent name"
+      },
+      {
+        "index":false,
+        "name":"vendor",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Block device vendor string"
+      },
+      {
+        "index":false,
+        "name":"model",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Block device model string identifier"
+      },
+      {
+        "index":false,
+        "name":"size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Block device size in blocks"
+      },
+      {
+        "index":false,
+        "name":"block_size",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Block size in bytes"
+      },
+      {
+        "index":false,
+        "name":"uuid",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Block device Universally Unique Identifier"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Block device type string"
+      },
+      {
+        "index":false,
+        "name":"label",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Block device label string"
+      }
+    ],
+    "description":"Block (buffered access) device file nodes: disks, ramdisks, and DMG containers."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"browser_plugins",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/browser_plugins.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The local user that owns the plugin"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Plugin display name"
+      },
+      {
+        "index":false,
+        "name":"identifier",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Plugin identifier"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Plugin short version"
+      },
+      {
+        "index":false,
+        "name":"sdk",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Build SDK used to compile plugin"
+      },
+      {
+        "index":false,
+        "name":"description",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Plugin description text"
+      },
+      {
+        "index":false,
+        "name":"development_region",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Plugin language-localization"
+      },
+      {
+        "index":false,
+        "name":"native",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Plugin requires native execution"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to plugin bundle"
+      },
+      {
+        "index":false,
+        "name":"disabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Is the plugin disabled. 1 = Disabled"
+      }
+    ],
+    "description":"All C/NPAPI browser plugin details for all users."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"carbon_black_info",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/carbon_black_info.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"sensor_id",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Sensor ID of the Carbon Black sensor"
+      },
+      {
+        "index":false,
+        "name":"config_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Sensor group"
+      },
+      {
+        "index":false,
+        "name":"collect_store_files",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"If the sensor is configured to send back binaries to the Carbon Black server"
+      },
+      {
+        "index":false,
+        "name":"collect_module_loads",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"If the sensor is configured to capture module loads"
+      },
+      {
+        "index":false,
+        "name":"collect_module_info",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"If the sensor is configured to collect metadata of binaries"
+      },
+      {
+        "index":false,
+        "name":"collect_file_mods",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"If the sensor is configured to collect file modification events"
+      },
+      {
+        "index":false,
+        "name":"collect_reg_mods",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"If the sensor is configured to collect registry modification events"
+      },
+      {
+        "index":false,
+        "name":"collect_net_conns",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"If the sensor is configured to collect network connections"
+      },
+      {
+        "index":false,
+        "name":"collect_processes",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"If the sensor is configured to process events"
+      },
+      {
+        "index":false,
+        "name":"collect_cross_processes",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"If the sensor is configured to cross process events"
+      },
+      {
+        "index":false,
+        "name":"collect_emet_events",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"If the sensor is configured to EMET events"
+      },
+      {
+        "index":false,
+        "name":"collect_data_file_writes",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"If the sensor is configured to collect non binary file writes"
+      },
+      {
+        "index":false,
+        "name":"collect_process_user_context",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"If the sensor is configured to collect the user running a process"
+      },
+      {
+        "index":false,
+        "name":"collect_sensor_operations",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Unknown"
+      },
+      {
+        "index":false,
+        "name":"log_file_disk_quota_mb",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Event file disk quota in MB"
+      },
+      {
+        "index":false,
+        "name":"log_file_disk_quota_percentage",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Event file disk quota in a percentage"
+      },
+      {
+        "index":false,
+        "name":"protection_disabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"If the sensor is configured to report tamper events"
+      },
+      {
+        "index":false,
+        "name":"sensor_ip_addr",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"IP address of the sensor"
+      },
+      {
+        "index":false,
+        "name":"sensor_backend_server",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Carbon Black server"
+      },
+      {
+        "index":false,
+        "name":"event_queue",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Size in bytes of Carbon Black event files on disk"
+      },
+      {
+        "index":false,
+        "name":"binary_queue",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Size in bytes of binaries waiting to be sent to Carbon Black server"
+      }
+    ],
+    "description":"Returns info about a Carbon Black sensor install."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"carves",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/carves.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time at which the carve was kicked off"
+      },
+      {
+        "index":false,
+        "name":"sha256",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"A SHA256 sum of the carved archive"
+      },
+      {
+        "index":false,
+        "name":"size",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Size of the carved archive"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The path of the requested carve"
+      },
+      {
+        "index":false,
+        "name":"status",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Status of the carve, can be STARTING, PENDING, SUCCESS, or FAILED"
+      },
+      {
+        "index":false,
+        "name":"carve_guid",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Identifying value of the carve session"
+      },
+      {
+        "index":false,
+        "name":"carve",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Set this value to '1' to start a file carve"
+      }
+    ],
+    "description":"Forensic Carves."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"certificates",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/macwin/certificates.table",
+    "platforms":[
+      "darwin",
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"common_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Certificate CommonName"
+      },
+      {
+        "index":false,
+        "name":"subject",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Certificate distinguished name"
+      },
+      {
+        "index":false,
+        "name":"issuer",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Certificate issuer distinguished name"
+      },
+      {
+        "index":false,
+        "name":"ca",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if CA: true (certificate is an authority) else 0"
+      },
+      {
+        "index":false,
+        "name":"self_signed",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if self-signed, else 0"
+      },
+      {
+        "index":false,
+        "name":"not_valid_before",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Lower bound of valid date"
+      },
+      {
+        "index":false,
+        "name":"not_valid_after",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Certificate expiration data"
+      },
+      {
+        "index":false,
+        "name":"signing_algorithm",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Signing algorithm used"
+      },
+      {
+        "index":false,
+        "name":"key_algorithm",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Key algorithm used"
+      },
+      {
+        "index":false,
+        "name":"key_strength",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Key size used for RSA/DSA, or curve name"
+      },
+      {
+        "index":false,
+        "name":"key_usage",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Certificate key usage and extended key usage"
+      },
+      {
+        "index":false,
+        "name":"subject_key_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"SKID an optionally included SHA1"
+      },
+      {
+        "index":false,
+        "name":"authority_key_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"AKID an optionally included SHA1"
+      },
+      {
+        "index":false,
+        "name":"sha1",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"SHA1 hash of the raw certificate contents"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to Keychain or PEM bundle"
+      }
+    ],
+    "description":"Certificate Authorities installed in Keychains/ca-bundles."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"chocolatey_packages",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/windows/chocolatey_packages.table",
+    "platforms":[
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package display name"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package-supplied version"
+      },
+      {
+        "index":false,
+        "name":"summary",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package-supplied summary"
+      },
+      {
+        "index":false,
+        "name":"author",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Optional package author"
+      },
+      {
+        "index":false,
+        "name":"license",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"License under which package is launched"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path at which this package resides"
+      }
+    ],
+    "description":"Chocolatey packages installed in a system."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"chrome_extensions",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/chrome_extensions.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The local user that owns the extension"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Extension display name"
+      },
+      {
+        "index":false,
+        "name":"identifier",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Extension identifier"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Extension-supplied version"
+      },
+      {
+        "index":false,
+        "name":"description",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Extension-optional description"
+      },
+      {
+        "index":false,
+        "name":"locale",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Default locale supported by extension"
+      },
+      {
+        "index":false,
+        "name":"update_url",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Extension-supplied update URI"
+      },
+      {
+        "index":false,
+        "name":"author",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Optional extension author"
+      },
+      {
+        "index":false,
+        "name":"persistent",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If extension is persistent across all tabs else 0"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to extension folder"
+      }
+    ],
+    "description":"Chrome browser extensions."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"cpu_time",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/cpu_time.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"core",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Name of the cpu (core)"
+      },
+      {
+        "index":false,
+        "name":"user",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time spent in user mode"
+      },
+      {
+        "index":false,
+        "name":"nice",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time spent in user mode with low priority (nice)"
+      },
+      {
+        "index":false,
+        "name":"system",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time spent in system mode"
+      },
+      {
+        "index":false,
+        "name":"idle",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time spent in the idle task"
+      },
+      {
+        "index":false,
+        "name":"iowait",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time spent waiting for I/O to complete"
+      },
+      {
+        "index":false,
+        "name":"irq",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time spent servicing interrupts"
+      },
+      {
+        "index":false,
+        "name":"softirq",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time spent servicing softirqs"
+      },
+      {
+        "index":false,
+        "name":"steal",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time spent in other operating systems when running in a virtualized environment"
+      },
+      {
+        "index":false,
+        "name":"guest",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time spent running a virtual CPU for a guest OS under the control of the Linux kernel"
+      },
+      {
+        "index":false,
+        "name":"guest_nice",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time spent running a niced guest "
+      }
+    ],
+    "description":"Displays information from /proc/stat file about the time the cpu cores spent in different parts of the system."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"cpuid",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/cpuid.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"feature",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Present feature flags"
+      },
+      {
+        "index":false,
+        "name":"value",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Bit value or string"
+      },
+      {
+        "index":false,
+        "name":"output_register",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Register used to for feature value"
+      },
+      {
+        "index":false,
+        "name":"output_bit",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Bit in register value for feature value"
+      },
+      {
+        "index":false,
+        "name":"input_eax",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Value of EAX used"
+      }
+    ],
+    "description":"Useful CPU features from the cpuid ASM call."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"crashes",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/crashes.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Type of crash log"
+      },
+      {
+        "index":false,
+        "name":"pid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Process (or thread) ID of the crashed process"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to the crashed process"
+      },
+      {
+        "index":false,
+        "name":"crash_path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Location of log file"
+      },
+      {
+        "index":false,
+        "name":"identifier",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Identifier of the crashed process"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Version info of the crashed process"
+      },
+      {
+        "index":false,
+        "name":"parent",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Parent PID of the crashed process"
+      },
+      {
+        "index":false,
+        "name":"responsible",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Process responsible for the crashed process"
+      },
+      {
+        "index":false,
+        "name":"uid",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"User ID of the crashed process"
+      },
+      {
+        "index":false,
+        "name":"datetime",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Date/Time at which the crash occurred"
+      },
+      {
+        "index":false,
+        "name":"crashed_thread",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Thread ID which crashed"
+      },
+      {
+        "index":false,
+        "name":"stack_trace",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Most recent frame from the stack trace"
+      },
+      {
+        "index":false,
+        "name":"exception_type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Exception type of the crash"
+      },
+      {
+        "index":false,
+        "name":"exception_codes",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Exception codes from the crash"
+      },
+      {
+        "index":false,
+        "name":"exception_notes",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Exception notes from the crash"
+      },
+      {
+        "index":false,
+        "name":"registers",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The value of the system registers"
+      }
+    ],
+    "description":"Application, System, and Mobile App crash logs."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"crontab",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/crontab.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"event",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The job @event name (rare)"
+      },
+      {
+        "index":false,
+        "name":"minute",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The exact minute for the job"
+      },
+      {
+        "index":false,
+        "name":"hour",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The hour of the day for the job"
+      },
+      {
+        "index":false,
+        "name":"day_of_month",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The day of the month for the job"
+      },
+      {
+        "index":false,
+        "name":"month",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The month of the year for the job"
+      },
+      {
+        "index":false,
+        "name":"day_of_week",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The day of the week for the job"
+      },
+      {
+        "index":false,
+        "name":"command",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Raw command string"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"File parsed"
+      }
+    ],
+    "description":"Line parsed values from system and user cron/tab."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"curl",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/curl.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"url",
+        "required":true,
+        "hidden":false,
+        "type":"text",
+        "description":"The url for the request"
+      },
+      {
+        "index":false,
+        "name":"method",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The HTTP method for the request"
+      },
+      {
+        "index":false,
+        "name":"user_agent",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The user-agent string to use for the request"
+      },
+      {
+        "index":false,
+        "name":"response_code",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"The HTTP status code for the response"
+      },
+      {
+        "index":false,
+        "name":"round_trip_time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time taken to complete the request"
+      },
+      {
+        "index":false,
+        "name":"bytes",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Number of bytes in the response"
+      },
+      {
+        "index":false,
+        "name":"result",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The HTTP response body"
+      }
+    ],
+    "description":"Perform an http request and return stats about it."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"curl_certificate",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/curl_certificate.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"hostname",
+        "required":true,
+        "hidden":false,
+        "type":"text",
+        "description":"Hostname (domain[:port]) to CURL"
+      },
+      {
+        "index":false,
+        "name":"common_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Common name of company issued to"
+      },
+      {
+        "index":false,
+        "name":"organization",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Organization issued to"
+      },
+      {
+        "index":false,
+        "name":"organization_unit",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Organization unit issued to"
+      },
+      {
+        "index":false,
+        "name":"serial_number",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Certificate serial number"
+      },
+      {
+        "index":false,
+        "name":"issuer_common_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Issuer common name"
+      },
+      {
+        "index":false,
+        "name":"issuer_organization",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Issuer organization"
+      },
+      {
+        "index":false,
+        "name":"issuer_organization_unit",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Issuer organization unit"
+      },
+      {
+        "index":false,
+        "name":"valid_from",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Period of validity start date"
+      },
+      {
+        "index":false,
+        "name":"valid_to",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Period of validity end date"
+      },
+      {
+        "index":false,
+        "name":"sha256_fingerprint",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"SHA-256 fingerprint"
+      },
+      {
+        "index":false,
+        "name":"sha1_fingerprint",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"SHA1 fingerprint"
+      }
+    ],
+    "description":"Inspect TLS certificates by connecting to input hostnames."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"deb_packages",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/linux/deb_packages.table",
+    "platforms":[
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package name"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package version"
+      },
+      {
+        "index":false,
+        "name":"source",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package source"
+      },
+      {
+        "index":false,
+        "name":"size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Package size in bytes"
+      },
+      {
+        "index":false,
+        "name":"arch",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package architecture"
+      },
+      {
+        "index":false,
+        "name":"revision",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package revision"
+      }
+    ],
+    "description":"The installed DEB package database."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"device_file",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/sleuthkit/device_file.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"device",
+        "required":true,
+        "hidden":false,
+        "type":"text",
+        "description":"Absolute file path to device node"
+      },
+      {
+        "index":false,
+        "name":"partition",
+        "required":true,
+        "hidden":false,
+        "type":"text",
+        "description":"A partition number"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"A logical path within the device node"
+      },
+      {
+        "index":false,
+        "name":"filename",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name portion of file path"
+      },
+      {
+        "index":false,
+        "name":"inode",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Filesystem inode number"
+      },
+      {
+        "index":false,
+        "name":"uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Owning user ID"
+      },
+      {
+        "index":false,
+        "name":"gid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Owning group ID"
+      },
+      {
+        "index":false,
+        "name":"mode",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Permission bits"
+      },
+      {
+        "index":false,
+        "name":"size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Size of file in bytes"
+      },
+      {
+        "index":false,
+        "name":"block_size",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Block size of filesystem"
+      },
+      {
+        "index":false,
+        "name":"atime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Last access time"
+      },
+      {
+        "index":false,
+        "name":"mtime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Last modification time"
+      },
+      {
+        "index":false,
+        "name":"ctime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Creation time"
+      },
+      {
+        "index":false,
+        "name":"hard_links",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of hard links"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"File status"
+      }
+    ],
+    "description":"Similar to the file table, but use TSK and allow block address access."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"device_firmware",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/device_firmware.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Type of device"
+      },
+      {
+        "index":false,
+        "name":"device",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The device name"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Firmware version"
+      }
+    ],
+    "description":"A best-effort list of discovered firmware versions."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"device_hash",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/sleuthkit/device_hash.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"device",
+        "required":true,
+        "hidden":false,
+        "type":"text",
+        "description":"Absolute file path to device node"
+      },
+      {
+        "index":false,
+        "name":"partition",
+        "required":true,
+        "hidden":false,
+        "type":"text",
+        "description":"A partition number"
+      },
+      {
+        "index":false,
+        "name":"inode",
+        "required":true,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Filesystem inode number"
+      },
+      {
+        "index":false,
+        "name":"md5",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"MD5 hash of provided inode data"
+      },
+      {
+        "index":false,
+        "name":"sha1",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"SHA1 hash of provided inode data"
+      },
+      {
+        "index":false,
+        "name":"sha256",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"SHA256 hash of provided inode data"
+      }
+    ],
+    "description":"Similar to the hash table, but use TSK and allow block address access."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"device_partitions",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/sleuthkit/device_partitions.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"device",
+        "required":true,
+        "hidden":false,
+        "type":"text",
+        "description":"Absolute file path to device node"
+      },
+      {
+        "index":false,
+        "name":"partition",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"A partition number or description"
+      },
+      {
+        "index":false,
+        "name":"label",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":""
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":""
+      },
+      {
+        "index":false,
+        "name":"offset",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":""
+      },
+      {
+        "index":false,
+        "name":"blocks_size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Byte size of each block"
+      },
+      {
+        "index":false,
+        "name":"blocks",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Number of blocks"
+      },
+      {
+        "index":false,
+        "name":"inodes",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Number of meta nodes"
+      },
+      {
+        "index":false,
+        "name":"flags",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":""
+      }
+    ],
+    "description":"Use TSK to enumerate details about partitions on a disk device."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"disk_encryption",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/disk_encryption.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Disk name"
+      },
+      {
+        "index":false,
+        "name":"uuid",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Disk Universally Unique Identifier"
+      },
+      {
+        "index":false,
+        "name":"encrypted",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If encrypted: true (disk is encrypted), else 0"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Description of cipher type and mode if available"
+      },
+      {
+        "index":false,
+        "name":"uid",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Currently authenticated user if available (Apple)"
+      },
+      {
+        "index":false,
+        "name":"user_uuid",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"UUID of authenticated user if available (Apple)"
+      }
+    ],
+    "description":"Disk encryption status and information."
+  },
+  {
+    "cacheable":false,
+    "evented":true,
+    "name":"disk_events",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/disk_events.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"action",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Appear or disappear"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path of the DMG file accessed"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Disk event name"
+      },
+      {
+        "index":false,
+        "name":"device",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Disk event BSD name"
+      },
+      {
+        "index":false,
+        "name":"uuid",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"UUID of the volume inside DMG if available"
+      },
+      {
+        "index":false,
+        "name":"size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Size of partition in bytes"
+      },
+      {
+        "index":false,
+        "name":"ejectable",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if ejectable, 0 if not"
+      },
+      {
+        "index":false,
+        "name":"mountable",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if mountable, 0 if not"
+      },
+      {
+        "index":false,
+        "name":"writable",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if writable, 0 if not"
+      },
+      {
+        "index":false,
+        "name":"content",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Disk event content"
+      },
+      {
+        "index":false,
+        "name":"media_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Disk event media name string"
+      },
+      {
+        "index":false,
+        "name":"vendor",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Disk event vendor string"
+      },
+      {
+        "index":false,
+        "name":"filesystem",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Filesystem if available"
+      },
+      {
+        "index":false,
+        "name":"checksum",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"UDIF Master checksum if available (CRC32)"
+      },
+      {
+        "index":false,
+        "name":"time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time of appearance/disappearance in UNIX time"
+      },
+      {
+        "index":false,
+        "name":"eid",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"Event ID"
+      }
+    ],
+    "description":"Track DMG disk image events (appearance/disappearance) when opened."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"dns_resolvers",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/dns_resolvers.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"id",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Address type index or order"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Address type: sortlist, nameserver, search"
+      },
+      {
+        "index":false,
+        "name":"address",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Resolver IP/IPv6 address"
+      },
+      {
+        "index":false,
+        "name":"netmask",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Address (sortlist) netmask length"
+      },
+      {
+        "index":false,
+        "name":"options",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Resolver options"
+      }
+    ],
+    "description":"Resolvers used by this host."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"docker_container_labels",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/docker_container_labels.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Container ID"
+      },
+      {
+        "index":false,
+        "name":"key",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Label key"
+      },
+      {
+        "index":false,
+        "name":"value",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Optional label value"
+      }
+    ],
+    "description":"Docker container labels."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"docker_container_mounts",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/docker_container_mounts.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Container ID"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Type of mount (bind, volume)"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Optional mount name"
+      },
+      {
+        "index":false,
+        "name":"source",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Source path on host"
+      },
+      {
+        "index":false,
+        "name":"destination",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Destination path inside container"
+      },
+      {
+        "index":false,
+        "name":"driver",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Driver providing the mount"
+      },
+      {
+        "index":false,
+        "name":"mode",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Mount options (rw, ro)"
+      },
+      {
+        "index":false,
+        "name":"rw",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if read/write. 0 otherwise"
+      },
+      {
+        "index":false,
+        "name":"propagation",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Mount propagation"
+      }
+    ],
+    "description":"Docker container mounts."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"docker_container_networks",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/docker_container_networks.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Container ID"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Network name"
+      },
+      {
+        "index":false,
+        "name":"network_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Network ID"
+      },
+      {
+        "index":false,
+        "name":"endpoint_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Endpoint ID"
+      },
+      {
+        "index":false,
+        "name":"gateway",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Gateway"
+      },
+      {
+        "index":false,
+        "name":"ip_address",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"IP address"
+      },
+      {
+        "index":false,
+        "name":"ip_prefix_len",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"IP subnet prefix length"
+      },
+      {
+        "index":false,
+        "name":"ipv6_gateway",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"IPv6 gateway"
+      },
+      {
+        "index":false,
+        "name":"ipv6_address",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"IPv6 address"
+      },
+      {
+        "index":false,
+        "name":"ipv6_prefix_len",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"IPv6 subnet prefix length"
+      },
+      {
+        "index":false,
+        "name":"mac_address",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"MAC address"
+      }
+    ],
+    "description":"Docker container networks."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"docker_container_ports",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/docker_container_ports.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Container ID"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Protocol (tcp, udp)"
+      },
+      {
+        "index":false,
+        "name":"port",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Port inside the container"
+      },
+      {
+        "index":false,
+        "name":"host_ip",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Host IP address on which public port is listening"
+      },
+      {
+        "index":false,
+        "name":"host_port",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Host port"
+      }
+    ],
+    "description":"Docker container ports."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"docker_container_processes",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/docker_container_processes.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"id",
+        "required":true,
+        "hidden":false,
+        "type":"text",
+        "description":"Container ID"
+      },
+      {
+        "index":false,
+        "name":"pid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Process ID"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The process path or shorthand argv[0]"
+      },
+      {
+        "index":false,
+        "name":"cmdline",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Complete argv"
+      },
+      {
+        "index":false,
+        "name":"state",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Process state"
+      },
+      {
+        "index":false,
+        "name":"uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"User ID"
+      },
+      {
+        "index":false,
+        "name":"gid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Group ID"
+      },
+      {
+        "index":false,
+        "name":"euid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Effective user ID"
+      },
+      {
+        "index":false,
+        "name":"egid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Effective group ID"
+      },
+      {
+        "index":false,
+        "name":"suid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Saved user ID"
+      },
+      {
+        "index":false,
+        "name":"sgid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Saved group ID"
+      },
+      {
+        "index":false,
+        "name":"wired_size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Bytes of unpagable memory used by process"
+      },
+      {
+        "index":false,
+        "name":"resident_size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Bytes of private memory used by process"
+      },
+      {
+        "index":false,
+        "name":"total_size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total virtual memory size"
+      },
+      {
+        "index":false,
+        "name":"start_time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Process start in seconds since boot (non-sleeping)"
+      },
+      {
+        "index":false,
+        "name":"parent",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Process parent's PID"
+      },
+      {
+        "index":false,
+        "name":"pgroup",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Process group"
+      },
+      {
+        "index":false,
+        "name":"threads",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of threads used by process"
+      },
+      {
+        "index":false,
+        "name":"nice",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Process nice level (-20 to 20, default 0)"
+      },
+      {
+        "index":false,
+        "name":"user",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"User name"
+      },
+      {
+        "index":false,
+        "name":"time",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Cumulative CPU time. [DD-]HH:MM:SS format"
+      },
+      {
+        "index":false,
+        "name":"cpu",
+        "required":false,
+        "hidden":false,
+        "type":"double",
+        "description":"CPU utilization as percentage"
+      },
+      {
+        "index":false,
+        "name":"mem",
+        "required":false,
+        "hidden":false,
+        "type":"double",
+        "description":"Memory utilization as percentage"
+      }
+    ],
+    "description":"Docker container processes."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"docker_container_stats",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/docker_container_stats.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"id",
+        "required":true,
+        "hidden":false,
+        "type":"text",
+        "description":"Container ID"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Container name"
+      },
+      {
+        "index":false,
+        "name":"pids",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of processes"
+      },
+      {
+        "index":false,
+        "name":"read",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"UNIX time when stats were read"
+      },
+      {
+        "index":false,
+        "name":"preread",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"UNIX time when stats were last read"
+      },
+      {
+        "index":false,
+        "name":"interval",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Difference between read and preread in nano-seconds"
+      },
+      {
+        "index":false,
+        "name":"disk_read",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total disk read bytes"
+      },
+      {
+        "index":false,
+        "name":"disk_write",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total disk write bytes"
+      },
+      {
+        "index":false,
+        "name":"num_procs",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of processors"
+      },
+      {
+        "index":false,
+        "name":"cpu_total_usage",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total CPU usage"
+      },
+      {
+        "index":false,
+        "name":"cpu_kernelmode_usage",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"CPU kernel mode usage"
+      },
+      {
+        "index":false,
+        "name":"cpu_usermode_usage",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"CPU user mode usage"
+      },
+      {
+        "index":false,
+        "name":"system_cpu_usage",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"CPU system usage"
+      },
+      {
+        "index":false,
+        "name":"online_cpus",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Online CPUs"
+      },
+      {
+        "index":false,
+        "name":"pre_cpu_total_usage",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Last read total CPU usage"
+      },
+      {
+        "index":false,
+        "name":"pre_cpu_kernelmode_usage",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Last read CPU kernel mode usage"
+      },
+      {
+        "index":false,
+        "name":"pre_cpu_usermode_usage",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Last read CPU user mode usage"
+      },
+      {
+        "index":false,
+        "name":"pre_system_cpu_usage",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Last read CPU system usage"
+      },
+      {
+        "index":false,
+        "name":"pre_online_cpus",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Last read online CPUs"
+      },
+      {
+        "index":false,
+        "name":"memory_usage",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Memory usage"
+      },
+      {
+        "index":false,
+        "name":"memory_max_usage",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Memory maximum usage"
+      },
+      {
+        "index":false,
+        "name":"memory_limit",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Memory limit"
+      },
+      {
+        "index":false,
+        "name":"network_rx_bytes",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total network bytes read"
+      },
+      {
+        "index":false,
+        "name":"network_tx_bytes",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total network bytes transmitted"
+      }
+    ],
+    "description":"Docker container statistics. Queries on this table take at least one second."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"docker_containers",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/docker_containers.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Container ID"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Container name"
+      },
+      {
+        "index":false,
+        "name":"image",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Docker image (name) used to launch this container"
+      },
+      {
+        "index":false,
+        "name":"image_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Docker image ID"
+      },
+      {
+        "index":false,
+        "name":"command",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Command with arguments"
+      },
+      {
+        "index":false,
+        "name":"created",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time of creation as UNIX time"
+      },
+      {
+        "index":false,
+        "name":"state",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Container state (created, restarting, running, removing, paused, exited, dead)"
+      },
+      {
+        "index":false,
+        "name":"status",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Container status information"
+      }
+    ],
+    "description":"Docker containers information."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"docker_image_labels",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/docker_image_labels.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Image ID"
+      },
+      {
+        "index":false,
+        "name":"key",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Label key"
+      },
+      {
+        "index":false,
+        "name":"value",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Optional label value"
+      }
+    ],
+    "description":"Docker image labels."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"docker_images",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/docker_images.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Image ID"
+      },
+      {
+        "index":false,
+        "name":"created",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time of creation as UNIX time"
+      },
+      {
+        "index":false,
+        "name":"size_bytes",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Size of image in bytes"
+      },
+      {
+        "index":false,
+        "name":"tags",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Comma-separated list of repository tags"
+      }
+    ],
+    "description":"Docker images information."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"docker_info",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/docker_info.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Docker system ID"
+      },
+      {
+        "index":false,
+        "name":"containers",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Total number of containers"
+      },
+      {
+        "index":false,
+        "name":"containers_running",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of containers currently running"
+      },
+      {
+        "index":false,
+        "name":"containers_paused",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of containers in paused state"
+      },
+      {
+        "index":false,
+        "name":"containers_stopped",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of containers in stopped state"
+      },
+      {
+        "index":false,
+        "name":"images",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of images"
+      },
+      {
+        "index":false,
+        "name":"storage_driver",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Storage driver"
+      },
+      {
+        "index":false,
+        "name":"memory_limit",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if memory limit support is enabled. 0 otherwise"
+      },
+      {
+        "index":false,
+        "name":"swap_limit",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if swap limit support is enabled. 0 otherwise"
+      },
+      {
+        "index":false,
+        "name":"kernel_memory",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if kernel memory limit support is enabled. 0 otherwise"
+      },
+      {
+        "index":false,
+        "name":"cpu_cfs_period",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if CPU Completely Fair Scheduler (CFS) period support is enabled. 0 otherwise"
+      },
+      {
+        "index":false,
+        "name":"cpu_cfs_quota",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if CPU Completely Fair Scheduler (CFS) quota support is enabled. 0 otherwise"
+      },
+      {
+        "index":false,
+        "name":"cpu_shares",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if CPU share weighting support is enabled. 0 otherwise"
+      },
+      {
+        "index":false,
+        "name":"cpu_set",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if CPU set selection support is enabled. 0 otherwise"
+      },
+      {
+        "index":false,
+        "name":"ipv4_forwarding",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if IPv4 forwarding is enabled. 0 otherwise"
+      },
+      {
+        "index":false,
+        "name":"bridge_nf_iptables",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if bridge netfilter iptables is enabled. 0 otherwise"
+      },
+      {
+        "index":false,
+        "name":"bridge_nf_ip6tables",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if bridge netfilter ip6tables is enabled. 0 otherwise"
+      },
+      {
+        "index":false,
+        "name":"oom_kill_disable",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if Out-of-memory kill is disabled. 0 otherwise"
+      },
+      {
+        "index":false,
+        "name":"logging_driver",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Logging driver"
+      },
+      {
+        "index":false,
+        "name":"cgroup_driver",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Control groups driver"
+      },
+      {
+        "index":false,
+        "name":"kernel_version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Kernel version"
+      },
+      {
+        "index":false,
+        "name":"os",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Operating system"
+      },
+      {
+        "index":false,
+        "name":"os_type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Operating system type"
+      },
+      {
+        "index":false,
+        "name":"architecture",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Hardware architecture"
+      },
+      {
+        "index":false,
+        "name":"cpus",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of CPUs"
+      },
+      {
+        "index":false,
+        "name":"memory",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total memory"
+      },
+      {
+        "index":false,
+        "name":"http_proxy",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"HTTP proxy"
+      },
+      {
+        "index":false,
+        "name":"https_proxy",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"HTTPS proxy"
+      },
+      {
+        "index":false,
+        "name":"no_proxy",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Comma-separated list of domain extensions proxy should not be used for"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the docker host"
+      },
+      {
+        "index":false,
+        "name":"server_version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Server version"
+      },
+      {
+        "index":false,
+        "name":"root_dir",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Docker root directory"
+      }
+    ],
+    "description":"Docker system information."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"docker_network_labels",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/docker_network_labels.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Network ID"
+      },
+      {
+        "index":false,
+        "name":"key",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Label key"
+      },
+      {
+        "index":false,
+        "name":"value",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Optional label value"
+      }
+    ],
+    "description":"Docker network labels."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"docker_networks",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/docker_networks.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Network ID"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Network name"
+      },
+      {
+        "index":false,
+        "name":"driver",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Network driver"
+      },
+      {
+        "index":false,
+        "name":"created",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time of creation as UNIX time"
+      },
+      {
+        "index":false,
+        "name":"enable_ipv6",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if IPv6 is enabled on this network. 0 otherwise"
+      },
+      {
+        "index":false,
+        "name":"subnet",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Network subnet"
+      },
+      {
+        "index":false,
+        "name":"gateway",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Network gateway"
+      }
+    ],
+    "description":"Docker networks information."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"docker_version",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/docker_version.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Docker version"
+      },
+      {
+        "index":false,
+        "name":"api_version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"API version"
+      },
+      {
+        "index":false,
+        "name":"min_api_version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Minimum API version supported"
+      },
+      {
+        "index":false,
+        "name":"git_commit",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Docker build git commit"
+      },
+      {
+        "index":false,
+        "name":"go_version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Go version"
+      },
+      {
+        "index":false,
+        "name":"os",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Operating system"
+      },
+      {
+        "index":false,
+        "name":"arch",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Hardware architecture"
+      },
+      {
+        "index":false,
+        "name":"kernel_version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Kernel version"
+      },
+      {
+        "index":false,
+        "name":"build_time",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Build time"
+      }
+    ],
+    "description":"Docker version information."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"docker_volume_labels",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/docker_volume_labels.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Volume name"
+      },
+      {
+        "index":false,
+        "name":"key",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Label key"
+      },
+      {
+        "index":false,
+        "name":"value",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Optional label value"
+      }
+    ],
+    "description":"Docker volume labels."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"docker_volumes",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/docker_volumes.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Volume name"
+      },
+      {
+        "index":false,
+        "name":"driver",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Volume driver"
+      },
+      {
+        "index":false,
+        "name":"mount_point",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Mount point"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Volume type"
+      }
+    ],
+    "description":"Docker volumes information."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"drivers",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/windows/drivers.table",
+    "platforms":[
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"device_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Device ID"
+      },
+      {
+        "index":false,
+        "name":"device_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Device name"
+      },
+      {
+        "index":false,
+        "name":"image",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to driver image file"
+      },
+      {
+        "index":false,
+        "name":"description",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Driver description"
+      },
+      {
+        "index":false,
+        "name":"service",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Driver service name, if one exists"
+      },
+      {
+        "index":false,
+        "name":"service_key",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Driver service registry key"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Driver version"
+      },
+      {
+        "index":false,
+        "name":"inf",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Associated inf file"
+      },
+      {
+        "index":false,
+        "name":"class",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Device/driver class name"
+      },
+      {
+        "index":false,
+        "name":"provider",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Driver provider"
+      },
+      {
+        "index":false,
+        "name":"manufacturer",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Device manufacturer"
+      },
+      {
+        "index":false,
+        "name":"driver_key",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Driver key"
+      },
+      {
+        "index":false,
+        "name":"date",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Driver date"
+      }
+    ],
+    "description":"Details for in-use Windows device drivers. This does not display installed but unused drivers."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"ec2_instance_metadata",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/linux/ec2_instance_metadata.table",
+    "platforms":[
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"instance_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"EC2 instance ID"
+      },
+      {
+        "index":false,
+        "name":"instance_type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"EC2 instance type"
+      },
+      {
+        "index":false,
+        "name":"architecture",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Hardware architecture of this EC2 instance"
+      },
+      {
+        "index":false,
+        "name":"region",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"AWS region in which this instance launched"
+      },
+      {
+        "index":false,
+        "name":"availability_zone",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Availability zone in which this instance launched"
+      },
+      {
+        "index":false,
+        "name":"local_hostname",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Private IPv4 DNS hostname of the first interface of this instance"
+      },
+      {
+        "index":false,
+        "name":"local_ipv4",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Private IPv4 address of the first interface of this instance"
+      },
+      {
+        "index":false,
+        "name":"mac",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"MAC address for the first network interface of this EC2 instance"
+      },
+      {
+        "index":false,
+        "name":"security_groups",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Comma separated list of security group names"
+      },
+      {
+        "index":false,
+        "name":"iam_arn",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"If there is an IAM role associated with the instance, contains instance profile ARN"
+      },
+      {
+        "index":false,
+        "name":"ami_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"AMI ID used to launch this EC2 instance"
+      },
+      {
+        "index":false,
+        "name":"reservation_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"ID of the reservation"
+      },
+      {
+        "index":false,
+        "name":"account_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"AWS account ID which owns this EC2 instance"
+      },
+      {
+        "index":false,
+        "name":"ssh_public_key",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"SSH public key. Only available if supplied at instance launch time"
+      }
+    ],
+    "description":"EC2 instance metadata."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"ec2_instance_tags",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/linux/ec2_instance_tags.table",
+    "platforms":[
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"instance_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"EC2 instance ID"
+      },
+      {
+        "index":false,
+        "name":"key",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Tag key"
+      },
+      {
+        "index":false,
+        "name":"value",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Tag value"
+      }
+    ],
+    "description":"EC2 instance tag key value pairs."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"etc_hosts",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/etc_hosts.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"address",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"IP address mapping"
+      },
+      {
+        "index":false,
+        "name":"hostnames",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Raw hosts mapping"
+      }
+    ],
+    "description":"Line-parsed /etc/hosts."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"etc_protocols",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/etc_protocols.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Protocol name"
+      },
+      {
+        "index":false,
+        "name":"number",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Protocol number"
+      },
+      {
+        "index":false,
+        "name":"alias",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Protocol alias"
+      },
+      {
+        "index":false,
+        "name":"comment",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Comment with protocol description"
+      }
+    ],
+    "description":"Line-parsed /etc/protocols."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"etc_services",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/etc_services.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Service name"
+      },
+      {
+        "index":false,
+        "name":"port",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Service port number"
+      },
+      {
+        "index":false,
+        "name":"protocol",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Transport protocol (TCP/UDP)"
+      },
+      {
+        "index":false,
+        "name":"aliases",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Optional space separated list of other names for a service"
+      },
+      {
+        "index":false,
+        "name":"comment",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Optional comment for a service."
+      }
+    ],
+    "description":"Line-parsed /etc/services."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"event_taps",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/event_taps.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Is the Event Tap enabled"
+      },
+      {
+        "index":false,
+        "name":"event_tap_id",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Unique ID for the Tap"
+      },
+      {
+        "index":false,
+        "name":"event_tapped",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The mask that identifies the set of events to be observed."
+      },
+      {
+        "index":false,
+        "name":"process_being_tapped",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"The process ID of the target application"
+      },
+      {
+        "index":false,
+        "name":"tapping_process",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"The process ID of the application that created the event tap."
+      }
+    ],
+    "description":"Returns information about installed event taps."
+  },
+  {
+    "cacheable":false,
+    "evented":true,
+    "name":"example",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/example.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Description for name column"
+      },
+      {
+        "index":false,
+        "name":"points",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"This is a signed SQLite int column"
+      },
+      {
+        "index":false,
+        "name":"size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"This is a signed SQLite bigint column"
+      },
+      {
+        "index":false,
+        "name":"action",
+        "required":true,
+        "hidden":false,
+        "type":"text",
+        "description":"Action performed in generation"
+      },
+      {
+        "index":false,
+        "name":"id",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"An index of some sort"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path of example"
+      }
+    ],
+    "description":"This is an example table spec."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"extended_attributes",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/extended_attributes.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"path",
+        "required":true,
+        "hidden":false,
+        "type":"text",
+        "description":"Absolute file path"
+      },
+      {
+        "index":false,
+        "name":"directory",
+        "required":true,
+        "hidden":false,
+        "type":"text",
+        "description":"Directory of file(s)"
+      },
+      {
+        "index":false,
+        "name":"key",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the value generated from the extended attribute"
+      },
+      {
+        "index":false,
+        "name":"value",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The parsed information from the attribute"
+      },
+      {
+        "index":false,
+        "name":"base64",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if the value is base64 encoded else 0"
+      }
+    ],
+    "description":"Returns the extended attributes for files (similar to Windows ADS)."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"fan_speed_sensors",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/fan_speed_sensors.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"fan",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Fan number"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Fan name"
+      },
+      {
+        "index":false,
+        "name":"actual",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Actual speed"
+      },
+      {
+        "index":false,
+        "name":"min",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Minimum speed"
+      },
+      {
+        "index":false,
+        "name":"max",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Maximum speed"
+      },
+      {
+        "index":false,
+        "name":"target",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Target speed"
+      }
+    ],
+    "description":"Fan speeds."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"fbsd_kmods",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/freebsd/fbsd_kmods.table",
+    "platforms":[
+      "freebsd"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Module name"
+      },
+      {
+        "index":false,
+        "name":"size",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Size of module content"
+      },
+      {
+        "index":false,
+        "name":"refs",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Module reverse dependencies"
+      },
+      {
+        "index":false,
+        "name":"address",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Kernel module address"
+      }
+    ],
+    "description":"Loaded FreeBSD kernel modules."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"file",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/utility/file.table",
+    "platforms":[
+      "darwin",
+      "linux",
+      "freebsd",
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"path",
+        "required":true,
+        "hidden":false,
+        "type":"text",
+        "description":"Absolute file path"
+      },
+      {
+        "index":false,
+        "name":"directory",
+        "required":true,
+        "hidden":false,
+        "type":"text",
+        "description":"Directory of file(s)"
+      },
+      {
+        "index":false,
+        "name":"filename",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name portion of file path"
+      },
+      {
+        "index":false,
+        "name":"inode",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Filesystem inode number"
+      },
+      {
+        "index":false,
+        "name":"uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Owning user ID"
+      },
+      {
+        "index":false,
+        "name":"gid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Owning group ID"
+      },
+      {
+        "index":false,
+        "name":"mode",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Permission bits"
+      },
+      {
+        "index":false,
+        "name":"device",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Device ID (optional)"
+      },
+      {
+        "index":false,
+        "name":"size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Size of file in bytes"
+      },
+      {
+        "index":false,
+        "name":"block_size",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Block size of filesystem"
+      },
+      {
+        "index":false,
+        "name":"atime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Last access time"
+      },
+      {
+        "index":false,
+        "name":"mtime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Last modification time"
+      },
+      {
+        "index":false,
+        "name":"ctime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Last status change time"
+      },
+      {
+        "index":false,
+        "name":"btime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"(B)irth or (cr)eate time"
+      },
+      {
+        "index":false,
+        "name":"hard_links",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of hard links"
+      },
+      {
+        "index":false,
+        "name":"symlink",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if the path is a symlink, otherwise 0"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"File status"
+      }
+    ],
+    "description":"Interactive filesystem attributes and metadata."
+  },
+  {
+    "cacheable":false,
+    "evented":true,
+    "name":"file_events",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/file_events.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"target_path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The path associated with the event"
+      },
+      {
+        "index":false,
+        "name":"category",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The category of the file defined in the config"
+      },
+      {
+        "index":false,
+        "name":"action",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Change action (UPDATE, REMOVE, etc)"
+      },
+      {
+        "index":false,
+        "name":"transaction_id",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"ID used during bulk update"
+      },
+      {
+        "index":false,
+        "name":"inode",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Filesystem inode number"
+      },
+      {
+        "index":false,
+        "name":"uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Owning user ID"
+      },
+      {
+        "index":false,
+        "name":"gid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Owning group ID"
+      },
+      {
+        "index":false,
+        "name":"mode",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Permission bits"
+      },
+      {
+        "index":false,
+        "name":"size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Size of file in bytes"
+      },
+      {
+        "index":false,
+        "name":"atime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Last access time"
+      },
+      {
+        "index":false,
+        "name":"mtime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Last modification time"
+      },
+      {
+        "index":false,
+        "name":"ctime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Last status change time"
+      },
+      {
+        "index":false,
+        "name":"md5",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The MD5 of the file after change"
+      },
+      {
+        "index":false,
+        "name":"sha1",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The SHA1 of the file after change"
+      },
+      {
+        "index":false,
+        "name":"sha256",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The SHA256 of the file after change"
+      },
+      {
+        "index":false,
+        "name":"hashed",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if the file was hashed, 0 if not, -1 if hashing failed"
+      },
+      {
+        "index":false,
+        "name":"time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time of file event"
+      },
+      {
+        "index":false,
+        "name":"eid",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"Event ID"
+      }
+    ],
+    "description":"Track time/action changes to files specified in configuration data."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"firefox_addons",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/firefox_addons.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The local user that owns the addon"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Addon display name"
+      },
+      {
+        "index":false,
+        "name":"identifier",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Addon identifier"
+      },
+      {
+        "index":false,
+        "name":"creator",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Addon-supported creator string"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Extension, addon, webapp"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Addon-supplied version string"
+      },
+      {
+        "index":false,
+        "name":"description",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Addon-supplied description string"
+      },
+      {
+        "index":false,
+        "name":"source_url",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"URL that installed the addon"
+      },
+      {
+        "index":false,
+        "name":"visible",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If the addon is shown in browser else 0"
+      },
+      {
+        "index":false,
+        "name":"active",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If the addon is active else 0"
+      },
+      {
+        "index":false,
+        "name":"disabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If the addon is application-disabled else 0"
+      },
+      {
+        "index":false,
+        "name":"autoupdate",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If the addon applies background updates else 0"
+      },
+      {
+        "index":false,
+        "name":"native",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If the addon includes binary components else 0"
+      },
+      {
+        "index":false,
+        "name":"location",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Global, profile location"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to plugin bundle"
+      }
+    ],
+    "description":"Firefox browser extensions, webapps, and addons."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"gatekeeper",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/gatekeeper.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"assessments_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If a Gatekeeper is enabled else 0"
+      },
+      {
+        "index":false,
+        "name":"dev_id_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If a Gatekeeper allows execution from identified developers else 0"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Version of Gatekeeper's gke.bundle"
+      },
+      {
+        "index":false,
+        "name":"opaque_version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Version of Gatekeeper's gkopaque.bundle"
+      }
+    ],
+    "description":"OS X Gatekeeper Details."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"gatekeeper_approved_apps",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/gatekeeper_approved_apps.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path of executable allowed to run"
+      },
+      {
+        "index":false,
+        "name":"requirement",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Code signing requirement language"
+      },
+      {
+        "index":false,
+        "name":"ctime",
+        "required":false,
+        "hidden":false,
+        "type":"double",
+        "description":"Last change time"
+      },
+      {
+        "index":false,
+        "name":"mtime",
+        "required":false,
+        "hidden":false,
+        "type":"double",
+        "description":"Last modification time"
+      }
+    ],
+    "description":"Gatekeeper apps a user has allowed to run."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"groups",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/groups.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"gid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Unsigned int64 group ID"
+      },
+      {
+        "index":false,
+        "name":"gid_signed",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"A signed int64 version of gid"
+      },
+      {
+        "index":false,
+        "name":"groupname",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Canonical local group name"
+      },
+      {
+        "index":false,
+        "name":"group_sid",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"Unique group ID"
+      },
+      {
+        "index":false,
+        "name":"comment",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"Remarks or comments associated with the group"
+      }
+    ],
+    "description":"Local system groups."
+  },
+  {
+    "cacheable":false,
+    "evented":true,
+    "name":"hardware_events",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/hardware_events.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"action",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Remove, insert, change properties, etc"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Local device path assigned (optional)"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Type of hardware and hardware event"
+      },
+      {
+        "index":false,
+        "name":"driver",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Driver claiming the device"
+      },
+      {
+        "index":false,
+        "name":"vendor",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Hardware device vendor"
+      },
+      {
+        "index":false,
+        "name":"vendor_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Hex encoded Hardware vendor identifier"
+      },
+      {
+        "index":false,
+        "name":"model",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Hardware device model"
+      },
+      {
+        "index":false,
+        "name":"model_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Hex encoded Hardware model identifier"
+      },
+      {
+        "index":false,
+        "name":"serial",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Device serial (optional)"
+      },
+      {
+        "index":false,
+        "name":"revision",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Device revision (optional)"
+      },
+      {
+        "index":false,
+        "name":"time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time of hardware event"
+      },
+      {
+        "index":false,
+        "name":"eid",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"Event ID"
+      }
+    ],
+    "description":"Hardware (PCI/USB/HID) events from UDEV or IOKit."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"hash",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/hash.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"path",
+        "required":true,
+        "hidden":false,
+        "type":"text",
+        "description":"Must provide a path or directory"
+      },
+      {
+        "index":false,
+        "name":"directory",
+        "required":true,
+        "hidden":false,
+        "type":"text",
+        "description":"Must provide a path or directory"
+      },
+      {
+        "index":false,
+        "name":"md5",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"MD5 hash of provided filesystem data"
+      },
+      {
+        "index":false,
+        "name":"sha1",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"SHA1 hash of provided filesystem data"
+      },
+      {
+        "index":false,
+        "name":"sha256",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"SHA256 hash of provided filesystem data"
+      }
+    ],
+    "description":"Filesystem hash data."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"homebrew_packages",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/homebrew_packages.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package name"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package install path"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Current 'linked' version"
+      }
+    ],
+    "description":"The installed homebrew package database."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"ie_extensions",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/windows/ie_extensions.table",
+    "platforms":[
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Extension display name"
+      },
+      {
+        "index":false,
+        "name":"registry_path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Extension identifier"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Version of the executable"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to executable"
+      }
+    ],
+    "description":"Internet Explorer browser extensions."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"intel_me_info",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/linwin/intel_me_info.table",
+    "platforms":[
+      "darwin",
+      "linux",
+      "freebsd",
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Intel ME version"
+      }
+    ],
+    "description":"Intel ME/CSE Info."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"interface_addresses",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/interface_addresses.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"interface",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Interface name"
+      },
+      {
+        "index":false,
+        "name":"address",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Specific address for interface"
+      },
+      {
+        "index":false,
+        "name":"mask",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Interface netmask"
+      },
+      {
+        "index":false,
+        "name":"broadcast",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Broadcast address for the interface"
+      },
+      {
+        "index":false,
+        "name":"point_to_point",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"PtP address for the interface"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Type of address. One of dhcp, manual, auto, other"
+      },
+      {
+        "index":false,
+        "name":"friendly_name",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"The friendly display name of the interface."
+      }
+    ],
+    "description":"Network interfaces and relevant metadata."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"interface_details",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/interface_details.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"interface",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Interface name"
+      },
+      {
+        "index":false,
+        "name":"mac",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"MAC of interface (optional)"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Interface type (includes virtual)"
+      },
+      {
+        "index":false,
+        "name":"mtu",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Network MTU"
+      },
+      {
+        "index":false,
+        "name":"metric",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Metric based on the speed of the interface"
+      },
+      {
+        "index":false,
+        "name":"flags",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Flags (netdevice) for the device"
+      },
+      {
+        "index":false,
+        "name":"ipackets",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Input packets"
+      },
+      {
+        "index":false,
+        "name":"opackets",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Output packets"
+      },
+      {
+        "index":false,
+        "name":"ibytes",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Input bytes"
+      },
+      {
+        "index":false,
+        "name":"obytes",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Output bytes"
+      },
+      {
+        "index":false,
+        "name":"ierrors",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Input errors"
+      },
+      {
+        "index":false,
+        "name":"oerrors",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Output errors"
+      },
+      {
+        "index":false,
+        "name":"idrops",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Input drops"
+      },
+      {
+        "index":false,
+        "name":"odrops",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Output drops"
+      },
+      {
+        "index":false,
+        "name":"collisions",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Packet Collisions detected"
+      },
+      {
+        "index":false,
+        "name":"last_change",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time of last device modification (optional)"
+      },
+      {
+        "index":false,
+        "name":"friendly_name",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"The friendly display name of the interface."
+      },
+      {
+        "index":false,
+        "name":"description",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"Short description of the object\u2014a one-line string."
+      },
+      {
+        "index":false,
+        "name":"manufacturer",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"Name of the network adapter's manufacturer."
+      },
+      {
+        "index":false,
+        "name":"connection_id",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"Name of the network connection as it appears in the Network Connections Control Panel program."
+      },
+      {
+        "index":false,
+        "name":"connection_status",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"State of the network adapter connection to the network."
+      },
+      {
+        "index":false,
+        "name":"enabled",
+        "required":false,
+        "hidden":true,
+        "type":"integer",
+        "description":"Indicates whether the adapter is enabled or not."
+      },
+      {
+        "index":false,
+        "name":"physical_adapter",
+        "required":false,
+        "hidden":true,
+        "type":"integer",
+        "description":"Indicates whether the adapter is a physical or a logical adapter."
+      },
+      {
+        "index":false,
+        "name":"speed",
+        "required":false,
+        "hidden":true,
+        "type":"integer",
+        "description":"Estimate of the current bandwidth in bits per second."
+      },
+      {
+        "index":false,
+        "name":"dhcp_enabled",
+        "required":false,
+        "hidden":true,
+        "type":"integer",
+        "description":"If TRUE, the dynamic host configuration protocol (DHCP) server automatically assigns an IP address to the computer system when establishing a network connection."
+      },
+      {
+        "index":false,
+        "name":"dhcp_lease_expires",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"Expiration date and time for a leased IP address that was assigned to the computer by the dynamic host configuration protocol (DHCP) server."
+      },
+      {
+        "index":false,
+        "name":"dhcp_lease_obtained",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"Date and time the lease was obtained for the IP address assigned to the computer by the dynamic host configuration protocol (DHCP) server."
+      },
+      {
+        "index":false,
+        "name":"dhcp_server",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"IP address of the dynamic host configuration protocol (DHCP) server."
+      },
+      {
+        "index":false,
+        "name":"dns_domain",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"Organization name followed by a period and an extension that indicates the type of organization, such as 'microsoft.com'."
+      },
+      {
+        "index":false,
+        "name":"dns_domain_suffix_search_order",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"Array of DNS domain suffixes to be appended to the end of host names during name resolution."
+      },
+      {
+        "index":false,
+        "name":"dns_host_name",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"Host name used to identify the local computer for authentication by some utilities."
+      },
+      {
+        "index":false,
+        "name":"dns_server_search_order",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"Array of server IP addresses to be used in querying for DNS servers."
+      }
+    ],
+    "description":"Detailed information and stats of network interfaces."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"iokit_devicetree",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/iokit_devicetree.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Device node name"
+      },
+      {
+        "index":false,
+        "name":"class",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Best matching device class (most-specific category)"
+      },
+      {
+        "index":false,
+        "name":"id",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"IOKit internal registry ID"
+      },
+      {
+        "index":false,
+        "name":"parent",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Parent device registry ID"
+      },
+      {
+        "index":false,
+        "name":"device_path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Device tree path"
+      },
+      {
+        "index":false,
+        "name":"service",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if the device conforms to IOService else 0"
+      },
+      {
+        "index":false,
+        "name":"busy_state",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if the device is in a busy state else 0"
+      },
+      {
+        "index":false,
+        "name":"retain_count",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"The device reference count"
+      },
+      {
+        "index":false,
+        "name":"depth",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Device nested depth"
+      }
+    ],
+    "description":"The IOKit registry matching the DeviceTree plane."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"iokit_registry",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/iokit_registry.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Default name of the node"
+      },
+      {
+        "index":false,
+        "name":"class",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Best matching device class (most-specific category)"
+      },
+      {
+        "index":false,
+        "name":"id",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"IOKit internal registry ID"
+      },
+      {
+        "index":false,
+        "name":"parent",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Parent registry ID"
+      },
+      {
+        "index":false,
+        "name":"busy_state",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if the node is in a busy state else 0"
+      },
+      {
+        "index":false,
+        "name":"retain_count",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"The node reference count"
+      },
+      {
+        "index":false,
+        "name":"depth",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Node nested depth"
+      }
+    ],
+    "description":"The full IOKit registry without selecting a plane."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"iptables",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/linux/iptables.table",
+    "platforms":[
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"filter_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Packet matching filter table name."
+      },
+      {
+        "index":false,
+        "name":"chain",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Size of module content."
+      },
+      {
+        "index":false,
+        "name":"policy",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Policy that applies for this rule."
+      },
+      {
+        "index":false,
+        "name":"target",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Target that applies for this rule."
+      },
+      {
+        "index":false,
+        "name":"protocol",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Protocol number identification."
+      },
+      {
+        "index":false,
+        "name":"src_port",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Protocol source port(s)."
+      },
+      {
+        "index":false,
+        "name":"dst_port",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Protocol destination port(s)."
+      },
+      {
+        "index":false,
+        "name":"src_ip",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Source IP address."
+      },
+      {
+        "index":false,
+        "name":"src_mask",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Source IP address mask."
+      },
+      {
+        "index":false,
+        "name":"iniface",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Input interface for the rule."
+      },
+      {
+        "index":false,
+        "name":"iniface_mask",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Input interface mask for the rule."
+      },
+      {
+        "index":false,
+        "name":"dst_ip",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Destination IP address."
+      },
+      {
+        "index":false,
+        "name":"dst_mask",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Destination IP address mask."
+      },
+      {
+        "index":false,
+        "name":"outiface",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Output interface for the rule."
+      },
+      {
+        "index":false,
+        "name":"outiface_mask",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Output interface mask for the rule."
+      },
+      {
+        "index":false,
+        "name":"match",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Matching rule that applies."
+      },
+      {
+        "index":false,
+        "name":"packets",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of matching packets for this rule."
+      },
+      {
+        "index":false,
+        "name":"bytes",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of matching bytes for this rule."
+      }
+    ],
+    "description":"Linux IP packet filtering and NAT tool."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"kernel_extensions",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/kernel_extensions.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"idx",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Extension load tag or index"
+      },
+      {
+        "index":false,
+        "name":"refs",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Reference count"
+      },
+      {
+        "index":false,
+        "name":"size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Bytes of wired memory used by extension"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Extension label"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Extension version"
+      },
+      {
+        "index":false,
+        "name":"linked_against",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Indexes of extensions this extension is linked against"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Optional path to extension bundle"
+      }
+    ],
+    "description":"OS X's kernel extensions, both loaded and within the load search path."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"kernel_info",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/kernel_info.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Kernel version"
+      },
+      {
+        "index":false,
+        "name":"arguments",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Kernel arguments"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Kernel path"
+      },
+      {
+        "index":false,
+        "name":"device",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Kernel device identifier"
+      }
+    ],
+    "description":"Basic active kernel information."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"kernel_integrity",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/linux/kernel_integrity.table",
+    "platforms":[
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"sycall_addr_modified",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"0 or 1, for whether a syscall table pointer is modified"
+      },
+      {
+        "index":false,
+        "name":"text_segment_hash",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Hash value for the kernel's .text memory segment"
+      }
+    ],
+    "description":"Various Linux kernel integrity checked attributes."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"kernel_modules",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/linux/kernel_modules.table",
+    "platforms":[
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Module name"
+      },
+      {
+        "index":false,
+        "name":"size",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Size of module content"
+      },
+      {
+        "index":false,
+        "name":"used_by",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Module reverse dependencies"
+      },
+      {
+        "index":false,
+        "name":"status",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Kernel module status"
+      },
+      {
+        "index":false,
+        "name":"address",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Kernel module address"
+      }
+    ],
+    "description":"Linux kernel modules both loaded and within the load search path."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"kernel_panics",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/kernel_panics.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Location of log file"
+      },
+      {
+        "index":false,
+        "name":"time",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Formatted time of the event"
+      },
+      {
+        "index":false,
+        "name":"registers",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"A space delimited line of register:value pairs"
+      },
+      {
+        "index":false,
+        "name":"frame_backtrace",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Backtrace of the crashed module"
+      },
+      {
+        "index":false,
+        "name":"module_backtrace",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Modules appearing in the crashed module's backtrace"
+      },
+      {
+        "index":false,
+        "name":"dependencies",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Module dependencies existing in crashed module's backtrace"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Process name corresponding to crashed thread"
+      },
+      {
+        "index":false,
+        "name":"os_version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Version of the operating system"
+      },
+      {
+        "index":false,
+        "name":"kernel_version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Version of the system kernel"
+      },
+      {
+        "index":false,
+        "name":"system_model",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Physical system model, for example 'MacBookPro12,1 (Mac-E43C1C25D4880AD6)'"
+      },
+      {
+        "index":false,
+        "name":"uptime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"System uptime at kernel panic in nanoseconds"
+      },
+      {
+        "index":false,
+        "name":"last_loaded",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Last loaded module before panic"
+      },
+      {
+        "index":false,
+        "name":"last_unloaded",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Last unloaded module before panic"
+      }
+    ],
+    "description":"System kernel panic logs."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"keychain_acls",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/keychain_acls.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"keychain_path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The path of the keychain"
+      },
+      {
+        "index":false,
+        "name":"authorizations",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"A space delimited set of authorization attributes"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The path of the authorized application"
+      },
+      {
+        "index":false,
+        "name":"description",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The description included with the ACL entry"
+      },
+      {
+        "index":false,
+        "name":"label",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"An optional label tag that may be included with the keychain entry"
+      }
+    ],
+    "description":"Applications that have ACL entries in the keychain."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"keychain_items",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/keychain_items.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"label",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Generic item name"
+      },
+      {
+        "index":false,
+        "name":"description",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Optional item description"
+      },
+      {
+        "index":false,
+        "name":"comment",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Optional keychain comment"
+      },
+      {
+        "index":false,
+        "name":"created",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Data item was created"
+      },
+      {
+        "index":false,
+        "name":"modified",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Date of last modification"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Keychain item type (class)"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to keychain containing item"
+      }
+    ],
+    "description":"Generic details about keychain items."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"known_hosts",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/known_hosts.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The local user that owns the known_hosts file"
+      },
+      {
+        "index":false,
+        "name":"key",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"parsed authorized keys line"
+      },
+      {
+        "index":false,
+        "name":"key_file",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to known_hosts file"
+      }
+    ],
+    "description":"A line-delimited known_hosts table."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"last",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/last.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"username",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Entry username"
+      },
+      {
+        "index":false,
+        "name":"tty",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Entry terminal"
+      },
+      {
+        "index":false,
+        "name":"pid",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Process (or thread) ID"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Entry type, according to ut_type types (utmp.h)"
+      },
+      {
+        "index":false,
+        "name":"time",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Entry timestamp"
+      },
+      {
+        "index":false,
+        "name":"host",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Entry hostname"
+      }
+    ],
+    "description":"System logins and logouts."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"launchd",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/launchd.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to daemon or agent plist"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"File name of plist (used by launchd)"
+      },
+      {
+        "index":false,
+        "name":"label",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Daemon or agent service name"
+      },
+      {
+        "index":false,
+        "name":"program",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to target program"
+      },
+      {
+        "index":false,
+        "name":"run_at_load",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Should the program run on launch load"
+      },
+      {
+        "index":false,
+        "name":"keep_alive",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Should the process be restarted if killed"
+      },
+      {
+        "index":false,
+        "name":"on_demand",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Deprecated key, replaced by keep_alive"
+      },
+      {
+        "index":false,
+        "name":"disabled",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Skip loading this daemon or agent on boot"
+      },
+      {
+        "index":false,
+        "name":"username",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Run this daemon or agent as this username"
+      },
+      {
+        "index":false,
+        "name":"groupname",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Run this daemon or agent as this group"
+      },
+      {
+        "index":false,
+        "name":"stdout_path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Pipe stdout to a target path"
+      },
+      {
+        "index":false,
+        "name":"stderr_path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Pipe stderr to a target path"
+      },
+      {
+        "index":false,
+        "name":"start_interval",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Frecuency of running in seconds"
+      },
+      {
+        "index":false,
+        "name":"program_arguments",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Command line arguments passed to program"
+      },
+      {
+        "index":false,
+        "name":"watch_paths",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Key that launches daemon or agent if path is modified"
+      },
+      {
+        "index":false,
+        "name":"queue_directories",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Similar to watch_paths but only with non-empty directories"
+      },
+      {
+        "index":false,
+        "name":"inetd_compatibility",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Run this daemon or agent as it was launched from inetd"
+      },
+      {
+        "index":false,
+        "name":"start_on_mount",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Run daemon or agent every time a filesystem is mounted"
+      },
+      {
+        "index":false,
+        "name":"root_directory",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Key used to specify a directory to chroot to before launch"
+      },
+      {
+        "index":false,
+        "name":"working_directory",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Key used to specify a directory to chdir to before launch"
+      },
+      {
+        "index":false,
+        "name":"process_type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Key describes the intended purpose of the job"
+      }
+    ],
+    "description":"LaunchAgents and LaunchDaemons from default search paths."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"launchd_overrides",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/launchd_overrides.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"label",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Daemon or agent service name"
+      },
+      {
+        "index":false,
+        "name":"key",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the override key"
+      },
+      {
+        "index":false,
+        "name":"value",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Overriden value"
+      },
+      {
+        "index":false,
+        "name":"uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"User ID applied to the override, 0 applies to all"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to daemon or agent plist"
+      }
+    ],
+    "description":"Override keys, per user, for LaunchDaemons and Agents."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"listening_ports",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/listening_ports.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"pid",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Process (or thread) ID"
+      },
+      {
+        "index":false,
+        "name":"port",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Transport layer port"
+      },
+      {
+        "index":false,
+        "name":"protocol",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Transport protocol (TCP/UDP)"
+      },
+      {
+        "index":false,
+        "name":"family",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Network protocol (IPv4, IPv6)"
+      },
+      {
+        "index":false,
+        "name":"address",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Specific address for bind"
+      }
+    ],
+    "description":"Processes with listening (bound) network sockets/ports."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"lldp_neighbors",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/lldpd/lldp_neighbors.table",
+    "platforms":[
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"interface",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Interface name"
+      },
+      {
+        "index":false,
+        "name":"rid",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Neighbor chassis index"
+      },
+      {
+        "index":false,
+        "name":"chassis_id_type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Neighbor chassis ID type"
+      },
+      {
+        "index":false,
+        "name":"chassis_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Neighbor chassis ID value"
+      },
+      {
+        "index":false,
+        "name":"chassis_sysname",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"CPU brand string, contains vendor and model"
+      },
+      {
+        "index":false,
+        "name":"chassis_sys_description",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Max number of CPU physical cores"
+      },
+      {
+        "index":false,
+        "name":"chassis_bridge_capability_available",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Chassis bridge capability availability"
+      },
+      {
+        "index":false,
+        "name":"chassis_bridge_capability_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Is chassis bridge capability enabled."
+      },
+      {
+        "index":false,
+        "name":"chassis_router_capability_available",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Chassis router capability availability"
+      },
+      {
+        "index":false,
+        "name":"chassis_router_capability_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Chassis router capability enabled"
+      },
+      {
+        "index":false,
+        "name":"chassis_repeater_capability_available",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Chassis repeater capability availability"
+      },
+      {
+        "index":false,
+        "name":"chassis_repeater_capability_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Chassis repeater capability enabled"
+      },
+      {
+        "index":false,
+        "name":"chassis_wlan_capability_available",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Chassis wlan capability availability"
+      },
+      {
+        "index":false,
+        "name":"chassis_wlan_capability_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Chassis wlan capability enabled"
+      },
+      {
+        "index":false,
+        "name":"chassis_tel_capability_available",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Chassis telephone capability availability"
+      },
+      {
+        "index":false,
+        "name":"chassis_tel_capability_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Chassis telephone capability enabled"
+      },
+      {
+        "index":false,
+        "name":"chassis_docsis_capability_available",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Chassis DOCSIS capability availability"
+      },
+      {
+        "index":false,
+        "name":"chassis_docsis_capability_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Chassis DOCSIS capability enabled"
+      },
+      {
+        "index":false,
+        "name":"chassis_station_capability_available",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Chassis station capability availability"
+      },
+      {
+        "index":false,
+        "name":"chassis_station_capability_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Chassis station capability enabled"
+      },
+      {
+        "index":false,
+        "name":"chassis_other_capability_available",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Chassis other capability availability"
+      },
+      {
+        "index":false,
+        "name":"chassis_other_capability_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Chassis other capability enabled"
+      },
+      {
+        "index":false,
+        "name":"chassis_mgmt_ips",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Comma delimited list of chassis management IPS"
+      },
+      {
+        "index":false,
+        "name":"port_id_type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Port ID type"
+      },
+      {
+        "index":false,
+        "name":"port_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Port ID value"
+      },
+      {
+        "index":false,
+        "name":"port_description",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Port description"
+      },
+      {
+        "index":false,
+        "name":"port_ttl",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Age of neighbor port"
+      },
+      {
+        "index":false,
+        "name":"port_mfs",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Port max frame size"
+      },
+      {
+        "index":false,
+        "name":"port_aggregation_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Port aggregation ID"
+      },
+      {
+        "index":false,
+        "name":"port_autoneg_supported",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Auto negotiation supported"
+      },
+      {
+        "index":false,
+        "name":"port_autoneg_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Is auto negotiation enabled"
+      },
+      {
+        "index":false,
+        "name":"port_mau_type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"MAU type"
+      },
+      {
+        "index":false,
+        "name":"port_autoneg_10baset_hd_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"10Base-T HD auto negotiation enabled"
+      },
+      {
+        "index":false,
+        "name":"port_autoneg_10baset_fd_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"10Base-T FD auto negotiation enabled"
+      },
+      {
+        "index":false,
+        "name":"port_autoneg_100basetx_hd_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"100Base-TX HD auto negotiation enabled"
+      },
+      {
+        "index":false,
+        "name":"port_autoneg_100basetx_fd_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"100Base-TX FD auto negotiation enabled"
+      },
+      {
+        "index":false,
+        "name":"port_autoneg_100baset2_hd_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"100Base-T2 HD auto negotiation enabled"
+      },
+      {
+        "index":false,
+        "name":"port_autoneg_100baset2_fd_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"100Base-T2 FD auto negotiation enabled"
+      },
+      {
+        "index":false,
+        "name":"port_autoneg_100baset4_hd_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"100Base-T4 HD auto negotiation enabled"
+      },
+      {
+        "index":false,
+        "name":"port_autoneg_100baset4_fd_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"100Base-T4 FD auto negotiation enabled"
+      },
+      {
+        "index":false,
+        "name":"port_autoneg_1000basex_hd_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1000Base-X HD auto negotiation enabled"
+      },
+      {
+        "index":false,
+        "name":"port_autoneg_1000basex_fd_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1000Base-X FD auto negotiation enabled"
+      },
+      {
+        "index":false,
+        "name":"port_autoneg_1000baset_hd_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1000Base-T HD auto negotiation enabled"
+      },
+      {
+        "index":false,
+        "name":"port_autoneg_1000baset_fd_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1000Base-T FD auto negotiation enabled"
+      },
+      {
+        "index":false,
+        "name":"power_device_type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Dot3 power device type"
+      },
+      {
+        "index":false,
+        "name":"power_mdi_supported",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"MDI power supported"
+      },
+      {
+        "index":false,
+        "name":"power_mdi_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Is MDI power enabled"
+      },
+      {
+        "index":false,
+        "name":"power_paircontrol_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Is power pair control enabled"
+      },
+      {
+        "index":false,
+        "name":"power_pairs",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Dot3 power pairs"
+      },
+      {
+        "index":false,
+        "name":"power_class",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Power class"
+      },
+      {
+        "index":false,
+        "name":"power_8023at_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Is 802.3at enabled"
+      },
+      {
+        "index":false,
+        "name":"power_8023at_power_type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"802.3at power type"
+      },
+      {
+        "index":false,
+        "name":"power_8023at_power_source",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"802.3at power source"
+      },
+      {
+        "index":false,
+        "name":"power_8023at_power_priority",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"802.3at power priority"
+      },
+      {
+        "index":false,
+        "name":"power_8023at_power_allocated",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"802.3at power allocated"
+      },
+      {
+        "index":false,
+        "name":"power_8023at_power_requested",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"802.3at power requested"
+      },
+      {
+        "index":false,
+        "name":"med_device_type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Chassis MED type"
+      },
+      {
+        "index":false,
+        "name":"med_capability_capabilities",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Is MED capabilities enabled"
+      },
+      {
+        "index":false,
+        "name":"med_capability_policy",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Is MED policy capability enabled"
+      },
+      {
+        "index":false,
+        "name":"med_capability_location",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Is MED location capability enabled"
+      },
+      {
+        "index":false,
+        "name":"med_capability_mdi_pse",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Is MED MDI PSE capability enabled"
+      },
+      {
+        "index":false,
+        "name":"med_capability_mdi_pd",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Is MED MDI PD capability enabled"
+      },
+      {
+        "index":false,
+        "name":"med_capability_inventory",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Is MED inventory capability enabled"
+      },
+      {
+        "index":false,
+        "name":"med_policies",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Comma delimited list of MED policies"
+      },
+      {
+        "index":false,
+        "name":"vlans",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Comma delimited list of vlan ids"
+      },
+      {
+        "index":false,
+        "name":"pvid",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Primary VLAN id"
+      },
+      {
+        "index":false,
+        "name":"ppvids_supported",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Comma delimited list of supported PPVIDs"
+      },
+      {
+        "index":false,
+        "name":"ppvids_enabled",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Comma delimited list of enabled PPVIDs"
+      },
+      {
+        "index":false,
+        "name":"pids",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Comma delimited list of PIDs"
+      }
+    ],
+    "description":"LLDP neighbors of interfaces."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"load_average",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/load_average.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"period",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Period over which the average is calculated."
+      },
+      {
+        "index":false,
+        "name":"average",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Load average over the specified period."
+      }
+    ],
+    "description":"Displays information about the system wide load averages."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"logged_in_users",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/logged_in_users.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Login type"
+      },
+      {
+        "index":false,
+        "name":"user",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"User login name"
+      },
+      {
+        "index":false,
+        "name":"tty",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Device name"
+      },
+      {
+        "index":false,
+        "name":"host",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Remote hostname"
+      },
+      {
+        "index":false,
+        "name":"time",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Time entry was made"
+      },
+      {
+        "index":false,
+        "name":"pid",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Process (or thread) ID"
+      }
+    ],
+    "description":"Users with an active shell on the system."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"logical_drives",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/windows/logical_drives.table",
+    "platforms":[
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"device_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The drive id, usually the drive name, e.g., 'C:'."
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The type of disk drive this logical drive represents."
+      },
+      {
+        "index":false,
+        "name":"free_space",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The amount of free space, in bytes, of the drive."
+      },
+      {
+        "index":false,
+        "name":"size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The total amount of space, in bytes, of the drive."
+      },
+      {
+        "index":false,
+        "name":"file_system",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The file system of the drive."
+      },
+      {
+        "index":false,
+        "name":"boot_partition",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"True if Windows booted from this drive."
+      }
+    ],
+    "description":"Details for logical drives on the system. A logical drive generally represents a single partition."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"magic",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/magic.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"path",
+        "required":true,
+        "hidden":false,
+        "type":"text",
+        "description":"Absolute path to target file"
+      },
+      {
+        "index":false,
+        "name":"data",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Magic number data from libmagic"
+      },
+      {
+        "index":false,
+        "name":"mime_type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"MIME type data from libmagic"
+      },
+      {
+        "index":false,
+        "name":"mime_encoding",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"MIME encoding data from libmagic"
+      }
+    ],
+    "description":"Magic number recognition library table."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"managed_policies",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/managed_policies.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"domain",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"System or manager-chosen domain key"
+      },
+      {
+        "index":false,
+        "name":"uuid",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Optional UUID assigned to policy set"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Policy key name"
+      },
+      {
+        "index":false,
+        "name":"value",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Policy value"
+      },
+      {
+        "index":false,
+        "name":"username",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Policy applies only this user"
+      },
+      {
+        "index":false,
+        "name":"manual",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if policy was loaded manually, otherwise 0"
+      }
+    ],
+    "description":"The managed configuration policies from AD, MDM, MCX, etc."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"md_devices",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/linux/md_devices.table",
+    "platforms":[
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"device_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"md device name"
+      },
+      {
+        "index":false,
+        "name":"status",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Current state of the array"
+      },
+      {
+        "index":false,
+        "name":"raid_level",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Current raid level of the array"
+      },
+      {
+        "index":false,
+        "name":"size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"size of the array in blocks"
+      },
+      {
+        "index":false,
+        "name":"chunk_size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"chunk size in bytes"
+      },
+      {
+        "index":false,
+        "name":"raid_disks",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of configured RAID disks in array"
+      },
+      {
+        "index":false,
+        "name":"nr_raid_disks",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of partitions or disk devices to comprise the array"
+      },
+      {
+        "index":false,
+        "name":"working_disks",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of working disks in array"
+      },
+      {
+        "index":false,
+        "name":"active_disks",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of active disks in array"
+      },
+      {
+        "index":false,
+        "name":"failed_disks",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of active disks in array"
+      },
+      {
+        "index":false,
+        "name":"spare_disks",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of active disks in array"
+      },
+      {
+        "index":false,
+        "name":"superblock_state",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"State of the superblock"
+      },
+      {
+        "index":false,
+        "name":"superblock_version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Version of the superblock"
+      },
+      {
+        "index":false,
+        "name":"superblock_update_time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Unix timestamp of last update"
+      },
+      {
+        "index":false,
+        "name":"bitmap_on_mem",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Pages allocated in in-memory bitmap, if enabled"
+      },
+      {
+        "index":false,
+        "name":"bitmap_chunk_size",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Bitmap chunk size"
+      },
+      {
+        "index":false,
+        "name":"bitmap_external_file",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"External referenced bitmap file"
+      },
+      {
+        "index":false,
+        "name":"recovery_progress",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Progress of the recovery activity"
+      },
+      {
+        "index":false,
+        "name":"recovery_finish",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Estimated duration of recovery activity"
+      },
+      {
+        "index":false,
+        "name":"recovery_speed",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Speed of recovery activity"
+      },
+      {
+        "index":false,
+        "name":"resync_progress",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Progress of the resync activity"
+      },
+      {
+        "index":false,
+        "name":"resync_finish",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Estimated duration of resync activity"
+      },
+      {
+        "index":false,
+        "name":"resync_speed",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Speed of resync activity"
+      },
+      {
+        "index":false,
+        "name":"reshape_progress",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Progress of the reshape activity"
+      },
+      {
+        "index":false,
+        "name":"reshape_finish",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Estimated duration of reshape activity"
+      },
+      {
+        "index":false,
+        "name":"reshape_speed",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Speed of reshape activity"
+      },
+      {
+        "index":false,
+        "name":"check_array_progress",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Progress of the resync activity"
+      },
+      {
+        "index":false,
+        "name":"check_array_finish",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Estimated duration of resync activity"
+      },
+      {
+        "index":false,
+        "name":"check_array_speed",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Speed of resync activity"
+      },
+      {
+        "index":false,
+        "name":"unused_devices",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Unused devices"
+      },
+      {
+        "index":false,
+        "name":"other",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Other information associated with array from /proc/mdstat"
+      }
+    ],
+    "description":"Software RAID array settings."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"md_drives",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/linux/md_drives.table",
+    "platforms":[
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"md_device_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"md device name"
+      },
+      {
+        "index":false,
+        "name":"drive_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Drive device name"
+      },
+      {
+        "index":false,
+        "name":"slot",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Slot position of disk"
+      },
+      {
+        "index":false,
+        "name":"state",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"State of the drive"
+      }
+    ],
+    "description":"Drive devices used for Software RAID."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"md_personalities",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/linux/md_personalities.table",
+    "platforms":[
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of personality supported by kernel"
+      }
+    ],
+    "description":"Software RAID setting supported by the kernel."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"memory_info",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/linux/memory_info.table",
+    "platforms":[
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"memory_total",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total amount of physical RAM, in bytes"
+      },
+      {
+        "index":false,
+        "name":"memory_free",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The amount of physical RAM, in bytes, left unused by the system"
+      },
+      {
+        "index":false,
+        "name":"buffers",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The amount of physical RAM, in bytes, used for file buffers"
+      },
+      {
+        "index":false,
+        "name":"cached",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The amount of physical RAM, in bytes, used as cache memory"
+      },
+      {
+        "index":false,
+        "name":"swap_cached",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The amount of swap, in bytes, used as cache memory"
+      },
+      {
+        "index":false,
+        "name":"active",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The total amount of buffer or page cache memory, in bytes, that is in active use"
+      },
+      {
+        "index":false,
+        "name":"inactive",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The total amount of buffer or page cache memory, in bytes, that are free and available"
+      },
+      {
+        "index":false,
+        "name":"swap_total",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The total amount of swap available, in bytes"
+      },
+      {
+        "index":false,
+        "name":"swap_free",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The total amount of swap free, in bytes"
+      }
+    ],
+    "description":"Main memory information in bytes."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"memory_map",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/linux/memory_map.table",
+    "platforms":[
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Region name"
+      },
+      {
+        "index":false,
+        "name":"start",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Start address of memory region"
+      },
+      {
+        "index":false,
+        "name":"end",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"End address of memory region"
+      }
+    ],
+    "description":"OS memory region map."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"mounts",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/mounts.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"device",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Mounted device"
+      },
+      {
+        "index":false,
+        "name":"device_alias",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Mounted device alias"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Mounted device path"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Mounted device type"
+      },
+      {
+        "index":false,
+        "name":"blocks_size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Block size in bytes"
+      },
+      {
+        "index":false,
+        "name":"blocks",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Mounted device used blocks"
+      },
+      {
+        "index":false,
+        "name":"blocks_free",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Mounted device free blocks"
+      },
+      {
+        "index":false,
+        "name":"blocks_available",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Mounted device available blocks"
+      },
+      {
+        "index":false,
+        "name":"inodes",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Mounted device used inodes"
+      },
+      {
+        "index":false,
+        "name":"inodes_free",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Mounted device free inodes"
+      },
+      {
+        "index":false,
+        "name":"flags",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Mounted device flags"
+      }
+    ],
+    "description":"System mounted devices and filesystems (not process specific)."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"msr",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/linux/msr.table",
+    "platforms":[
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"processor_number",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The processor number as reported in /proc/cpuinfo"
+      },
+      {
+        "index":false,
+        "name":"turbo_disabled",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Whether the turbo feature is disabled."
+      },
+      {
+        "index":false,
+        "name":"turbo_ratio_limit",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The turbo feature ratio limit."
+      },
+      {
+        "index":false,
+        "name":"platform_info",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Platform information."
+      },
+      {
+        "index":false,
+        "name":"perf_ctl",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Performance setting for the processor."
+      },
+      {
+        "index":false,
+        "name":"perf_status",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Performance status for the processor."
+      },
+      {
+        "index":false,
+        "name":"feature_control",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Bitfield controling enabled features."
+      },
+      {
+        "index":false,
+        "name":"rapl_power_limit",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Run Time Average Power Limiting power limit."
+      },
+      {
+        "index":false,
+        "name":"rapl_energy_status",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Run Time Average Power Limiting energy status."
+      },
+      {
+        "index":false,
+        "name":"rapl_power_units",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Run Time Average Power Limiting power units."
+      }
+    ],
+    "description":"Various pieces of data stored in the model specific register per processor. NOTE: the msr kernel module must be enabled, and osquery must be run as root."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"nfs_shares",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/nfs_shares.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"share",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Filesystem path to the share"
+      },
+      {
+        "index":false,
+        "name":"options",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Options string set on the export share"
+      },
+      {
+        "index":false,
+        "name":"readonly",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if the share is exported readonly else 0"
+      }
+    ],
+    "description":"NFS shares exported by the host."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"nvram",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/nvram.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Variable name"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Data type (CFData, CFString, etc)"
+      },
+      {
+        "index":false,
+        "name":"value",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Raw variable data"
+      }
+    ],
+    "description":"Apple NVRAM variable listing."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"opera_extensions",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/opera_extensions.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The local user that owns the extension"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Extension display name"
+      },
+      {
+        "index":false,
+        "name":"identifier",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Extension identifier"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Extension-supplied version"
+      },
+      {
+        "index":false,
+        "name":"description",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Extension-optional description"
+      },
+      {
+        "index":false,
+        "name":"locale",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Default locale supported by extension"
+      },
+      {
+        "index":false,
+        "name":"update_url",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Extension-supplied update URI"
+      },
+      {
+        "index":false,
+        "name":"author",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Optional extension author"
+      },
+      {
+        "index":false,
+        "name":"persistent",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If extension is persistent across all tabs else 0"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to extension folder"
+      }
+    ],
+    "description":"Opera browser extensions."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"os_version",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/os_version.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Distribution or product name"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Pretty, suitable for presentation, OS version"
+      },
+      {
+        "index":false,
+        "name":"major",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Major release version"
+      },
+      {
+        "index":false,
+        "name":"minor",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Minor release version"
+      },
+      {
+        "index":false,
+        "name":"patch",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Optional patch release"
+      },
+      {
+        "index":false,
+        "name":"build",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Optional build-specific or variant string"
+      },
+      {
+        "index":false,
+        "name":"platform",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"OS Platform or ID"
+      },
+      {
+        "index":false,
+        "name":"platform_like",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Closely related platforms"
+      },
+      {
+        "index":false,
+        "name":"codename",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"OS version codename"
+      }
+    ],
+    "description":"A single row containing the operating system name and version."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"osquery_events",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/utility/osquery_events.table",
+    "platforms":[
+      "darwin",
+      "linux",
+      "freebsd",
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Event publisher or subscriber name"
+      },
+      {
+        "index":false,
+        "name":"publisher",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the associated publisher"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Either publisher or subscriber"
+      },
+      {
+        "index":false,
+        "name":"subscriptions",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of subscriptions the publisher received or subscriber used"
+      },
+      {
+        "index":false,
+        "name":"events",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of events emitted or received since osquery started"
+      },
+      {
+        "index":false,
+        "name":"refreshes",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Publisher only: number of runloop restarts"
+      },
+      {
+        "index":false,
+        "name":"active",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if the publisher or subscriber is active else 0"
+      }
+    ],
+    "description":"Information about the event publishers and subscribers."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"osquery_extensions",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/utility/osquery_extensions.table",
+    "platforms":[
+      "darwin",
+      "linux",
+      "freebsd",
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"uuid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The transient ID assigned for communication"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Extension's name"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Extenion's version"
+      },
+      {
+        "index":false,
+        "name":"sdk_version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"osquery SDK version used to build the extension"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path of the extenion's domain socket or library path"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"SDK extension type: extension or module"
+      }
+    ],
+    "description":"List of active osquery extensions."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"osquery_flags",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/utility/osquery_flags.table",
+    "platforms":[
+      "darwin",
+      "linux",
+      "freebsd",
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Flag name"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Flag type"
+      },
+      {
+        "index":false,
+        "name":"description",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Flag description"
+      },
+      {
+        "index":false,
+        "name":"default_value",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Flag default value"
+      },
+      {
+        "index":false,
+        "name":"value",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Flag value"
+      },
+      {
+        "index":false,
+        "name":"shell_only",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Is the flag shell only?"
+      }
+    ],
+    "description":"Configurable flags that modify osquery's behavior."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"osquery_info",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/utility/osquery_info.table",
+    "platforms":[
+      "darwin",
+      "linux",
+      "freebsd",
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"pid",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Process (or thread/handle) ID"
+      },
+      {
+        "index":false,
+        "name":"uuid",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Unique ID provided by the system"
+      },
+      {
+        "index":false,
+        "name":"instance_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Unique, long-lived ID per instance of osquery"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"osquery toolkit version"
+      },
+      {
+        "index":false,
+        "name":"config_hash",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Hash of the working configuration state"
+      },
+      {
+        "index":false,
+        "name":"config_valid",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if the config was loaded and considered valid, else 0"
+      },
+      {
+        "index":false,
+        "name":"extensions",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"osquery extensions status"
+      },
+      {
+        "index":false,
+        "name":"build_platform",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"osquery toolkit build platform"
+      },
+      {
+        "index":false,
+        "name":"build_distro",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"osquery toolkit platform distribution name (os version)"
+      },
+      {
+        "index":false,
+        "name":"start_time",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"UNIX time in seconds when the process started"
+      },
+      {
+        "index":false,
+        "name":"watcher",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Process (or thread/handle) ID of optional watcher process"
+      }
+    ],
+    "description":"Top level information about the running version of osquery."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"osquery_packs",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/utility/osquery_packs.table",
+    "platforms":[
+      "darwin",
+      "linux",
+      "freebsd",
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The given name for this query pack"
+      },
+      {
+        "index":false,
+        "name":"platform",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Platforms this query is supported on"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Minimum osquery version that this query will run on"
+      },
+      {
+        "index":false,
+        "name":"shard",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Shard restriction limit, 1-100, 0 meaning no restriction"
+      },
+      {
+        "index":false,
+        "name":"discovery_cache_hits",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"The number of times that the discovery query used cached values since the last time the config was reloaded"
+      },
+      {
+        "index":false,
+        "name":"discovery_executions",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"The number of times that the discovery queries have been executed since the last time the config was reloaded"
+      },
+      {
+        "index":false,
+        "name":"active",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Whether this pack is active (the version, platform and discovery queries match) yes=1, no=0."
+      }
+    ],
+    "description":"Information about the current query packs that are loaded in osquery."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"osquery_registry",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/utility/osquery_registry.table",
+    "platforms":[
+      "darwin",
+      "linux",
+      "freebsd",
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"registry",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the osquery registry"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the plugin item"
+      },
+      {
+        "index":false,
+        "name":"owner_uuid",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Extension route UUID (0 for core)"
+      },
+      {
+        "index":false,
+        "name":"internal",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If the plugin is internal else 0"
+      },
+      {
+        "index":false,
+        "name":"active",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If this plugin is active else 0"
+      }
+    ],
+    "description":"List the osquery registry plugins."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"osquery_schedule",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/utility/osquery_schedule.table",
+    "platforms":[
+      "darwin",
+      "linux",
+      "freebsd",
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The given name for this query"
+      },
+      {
+        "index":false,
+        "name":"query",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The exact query to run"
+      },
+      {
+        "index":false,
+        "name":"interval",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"The interval in seconds to run this query, not an exact interval"
+      },
+      {
+        "index":false,
+        "name":"executions",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Number of times the query was executed"
+      },
+      {
+        "index":false,
+        "name":"last_executed",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"UNIX time stamp in seconds of the last completed execution"
+      },
+      {
+        "index":false,
+        "name":"blacklisted",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if the query is blacklisted else 0"
+      },
+      {
+        "index":false,
+        "name":"output_size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total number of bytes generated by the query"
+      },
+      {
+        "index":false,
+        "name":"wall_time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total wall time spent executing"
+      },
+      {
+        "index":false,
+        "name":"user_time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total user time spent executing"
+      },
+      {
+        "index":false,
+        "name":"system_time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total system time spent executing"
+      },
+      {
+        "index":false,
+        "name":"average_memory",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Average private memory left after executing"
+      }
+    ],
+    "description":"Information about the current queries that are scheduled in osquery."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"package_bom",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/package_bom.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"filepath",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package file or directory"
+      },
+      {
+        "index":false,
+        "name":"uid",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Expected user of file or directory"
+      },
+      {
+        "index":false,
+        "name":"gid",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Expected group of file or directory"
+      },
+      {
+        "index":false,
+        "name":"mode",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Expected permissions"
+      },
+      {
+        "index":false,
+        "name":"size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Expected file size"
+      },
+      {
+        "index":false,
+        "name":"modified_time",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Timestamp the file was installed"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":true,
+        "hidden":false,
+        "type":"text",
+        "description":"Path of package bom"
+      }
+    ],
+    "description":"OS X package bill of materials (BOM) file list."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"package_install_history",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/package_install_history.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"package_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Label packageIdentifiers"
+      },
+      {
+        "index":false,
+        "name":"time",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Label date as UNIX timestamp"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package display name"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package display version"
+      },
+      {
+        "index":false,
+        "name":"source",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Install source: usually the installer process name"
+      },
+      {
+        "index":false,
+        "name":"content_type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package content_type (optional)"
+      }
+    ],
+    "description":"OS X package install history."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"package_receipts",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/package_receipts.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"package_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package domain identifier"
+      },
+      {
+        "index":false,
+        "name":"package_filename",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"Filename of original .pkg file"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Installed package version"
+      },
+      {
+        "index":false,
+        "name":"location",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Optional relative install path on volume"
+      },
+      {
+        "index":false,
+        "name":"install_time",
+        "required":false,
+        "hidden":false,
+        "type":"double",
+        "description":"Timestamp of install time"
+      },
+      {
+        "index":false,
+        "name":"installer_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of installer process"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path of receipt plist"
+      }
+    ],
+    "description":"OS X package receipt details."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"patches",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/windows/patches.table",
+    "platforms":[
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"csname",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The name of the host the patch is installed on."
+      },
+      {
+        "index":false,
+        "name":"hotfix_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The KB ID of the patch."
+      },
+      {
+        "index":false,
+        "name":"caption",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Short description of the patch."
+      },
+      {
+        "index":false,
+        "name":"description",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Fuller description of the patch."
+      },
+      {
+        "index":false,
+        "name":"fix_comments",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Additional comments about the patch."
+      },
+      {
+        "index":false,
+        "name":"installed_by",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The system context in which the patch as installed."
+      },
+      {
+        "index":false,
+        "name":"install_date",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Indicates when the patch was installed. Lack of a value does not indicate that the patch was not installed."
+      },
+      {
+        "index":false,
+        "name":"installed_on",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The date when the patch was installed."
+      }
+    ],
+    "description":"Lists all the patches applied. Note: This does not include patches applied via MSI or downloaded from Windows Update (e.g. Service Packs)."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"pci_devices",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/pci_devices.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"pci_slot",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"PCI Device used slot"
+      },
+      {
+        "index":false,
+        "name":"pci_class",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"PCI Device class"
+      },
+      {
+        "index":false,
+        "name":"driver",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"PCI Device used driver"
+      },
+      {
+        "index":false,
+        "name":"vendor",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"PCI Device vendor"
+      },
+      {
+        "index":false,
+        "name":"vendor_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Hex encoded PCI Device vendor identifier"
+      },
+      {
+        "index":false,
+        "name":"model",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"PCI Device model"
+      },
+      {
+        "index":false,
+        "name":"model_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Hex encoded PCI Device model identifier"
+      }
+    ],
+    "description":"PCI devices active on the host system."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"physical_disk_performance",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/windows/physical_disk_performance.table",
+    "platforms":[
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the physical disk"
+      },
+      {
+        "index":false,
+        "name":"avg_disk_bytes_per_read",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Average number of bytes transferred from the disk during read operations"
+      },
+      {
+        "index":false,
+        "name":"avg_disk_bytes_per_write",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Average number of bytes transferred to the disk during write operations"
+      },
+      {
+        "index":false,
+        "name":"avg_disk_read_queue_length",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Average number of read requests that were queued for the selected disk during the sample interval"
+      },
+      {
+        "index":false,
+        "name":"avg_disk_write_queue_length",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Average number of write requests that were queued for the selected disk during the sample interval"
+      },
+      {
+        "index":false,
+        "name":"avg_disk_sec_per_read",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Average time, in seconds, of a read operation of data from the disk"
+      },
+      {
+        "index":false,
+        "name":"avg_disk_sec_per_write",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Average time, in seconds, of a write operation of data to the disk"
+      },
+      {
+        "index":false,
+        "name":"current_disk_queue_length",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of requests outstanding on the disk at the time the performance data is collected"
+      },
+      {
+        "index":false,
+        "name":"percent_disk_read_time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Percentage of elapsed time that the selected disk drive is busy servicing read requests"
+      },
+      {
+        "index":false,
+        "name":"percent_disk_write_time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Percentage of elapsed time that the selected disk drive is busy servicing write requests"
+      },
+      {
+        "index":false,
+        "name":"percent_disk_time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Percentage of elapsed time that the selected disk drive is busy servicing read or write requests"
+      },
+      {
+        "index":false,
+        "name":"percent_idle_time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Percentage of time during the sample interval that the disk was idle"
+      }
+    ],
+    "description":"Provides provides raw data from performance counters that monitor hard or fixed disk drives on the system."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"pipes",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/windows/pipes.table",
+    "platforms":[
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"pid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Process ID of the process to which the pipe belongs"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the pipe"
+      },
+      {
+        "index":false,
+        "name":"instances",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of instances of the named pipe"
+      },
+      {
+        "index":false,
+        "name":"max_instances",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"The maximum number of instances creatable for this pipe"
+      },
+      {
+        "index":false,
+        "name":"flags",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The flags indicating whether this pipe connection is a server or client end, and if the pipe for sending messages or bytes"
+      }
+    ],
+    "description":"Named and Anonymous pipes."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"pkg_packages",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/freebsd/pkg_packages.table",
+    "platforms":[
+      "freebsd"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package name"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package version"
+      },
+      {
+        "index":false,
+        "name":"flatsize",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Package size in bytes"
+      },
+      {
+        "index":false,
+        "name":"arch",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Architecture(s) supported"
+      }
+    ],
+    "description":"pkgng packages that are currently installed on the host system."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"platform_info",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/platform_info.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"vendor",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Platform code vendor"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Platform code version"
+      },
+      {
+        "index":false,
+        "name":"date",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Self-reported platform code update date"
+      },
+      {
+        "index":false,
+        "name":"revision",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"BIOS major and minor revision"
+      },
+      {
+        "index":false,
+        "name":"address",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Relative address of firmware mapping"
+      },
+      {
+        "index":false,
+        "name":"size",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Size in bytes of firmware"
+      },
+      {
+        "index":false,
+        "name":"volume_size",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"(Optional) size of firmware volume"
+      },
+      {
+        "index":false,
+        "name":"extra",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Platform-specific additional information"
+      }
+    ],
+    "description":"Information about EFI/UEFI/ROM and platform/boot."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"plist",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/plist.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"key",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Preference top-level key"
+      },
+      {
+        "index":false,
+        "name":"subkey",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Intemediate key path, includes lists/dicts"
+      },
+      {
+        "index":false,
+        "name":"value",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"String value of most CF types"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":true,
+        "hidden":false,
+        "type":"text",
+        "description":"(optional) read preferences from a plist"
+      }
+    ],
+    "description":"Read and parse a plist file."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"portage_keywords",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/linux/portage_keywords.table",
+    "platforms":[
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"package",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package name"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The version which are affected by the use flags, empty means all"
+      },
+      {
+        "index":false,
+        "name":"keyword",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The keyword applied to the package"
+      },
+      {
+        "index":false,
+        "name":"mask",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"If the package is masked"
+      },
+      {
+        "index":false,
+        "name":"unmask",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"If the package is unmasked"
+      }
+    ],
+    "description":"A summary about portage configurations like keywords, mask and unmask."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"portage_packages",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/linux/portage_packages.table",
+    "platforms":[
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"package",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package name"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The version which are affected by the use flags, empty means all"
+      },
+      {
+        "index":false,
+        "name":"slot",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The slot used by package"
+      },
+      {
+        "index":false,
+        "name":"build_time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Unix time when package was built"
+      },
+      {
+        "index":false,
+        "name":"repository",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"From which repository the ebuild was used"
+      },
+      {
+        "index":false,
+        "name":"eapi",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The eapi for the ebuild"
+      },
+      {
+        "index":false,
+        "name":"size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The size of the package"
+      },
+      {
+        "index":false,
+        "name":"world",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"If package is in the world file"
+      }
+    ],
+    "description":"List of currently installed packages."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"portage_use",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/linux/portage_use.table",
+    "platforms":[
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"package",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package name"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The version of the installed package"
+      },
+      {
+        "index":false,
+        "name":"use",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"USE flag which has been enabled for package"
+      }
+    ],
+    "description":"List of enabled portage USE values for specific package."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"power_sensors",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/power_sensors.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"key",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The SMC key on OS X"
+      },
+      {
+        "index":false,
+        "name":"category",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The sensor category: currents, voltage, wattage"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of power source"
+      },
+      {
+        "index":false,
+        "name":"value",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Power in Watts"
+      }
+    ],
+    "description":"Machine power (currents, voltages, wattages, etc) sensors."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"preferences",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/preferences.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"domain",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Application ID usually in com.name.product format"
+      },
+      {
+        "index":false,
+        "name":"key",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Preference top-level key"
+      },
+      {
+        "index":false,
+        "name":"subkey",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Intemediate key path, includes lists/dicts"
+      },
+      {
+        "index":false,
+        "name":"value",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"String value of most CF types"
+      },
+      {
+        "index":false,
+        "name":"forced",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if the value is forced/managed, else 0"
+      },
+      {
+        "index":false,
+        "name":"username",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"(optional) read preferences for a specific user"
+      },
+      {
+        "index":false,
+        "name":"host",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"'current' or 'any' host, where 'current' takes precedence"
+      }
+    ],
+    "description":"OS X defaults and managed preferences."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"process_envs",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/process_envs.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"pid",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Process (or thread) ID"
+      },
+      {
+        "index":false,
+        "name":"key",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Environment variable name"
+      },
+      {
+        "index":false,
+        "name":"value",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Environment variable value"
+      }
+    ],
+    "description":"A key/value table of environment variables for each process."
+  },
+  {
+    "cacheable":false,
+    "evented":true,
+    "name":"process_events",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/process_events.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"pid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Process (or thread) ID"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path of executed file"
+      },
+      {
+        "index":false,
+        "name":"mode",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"File mode permissions"
+      },
+      {
+        "index":false,
+        "name":"cmdline",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Command line arguments (argv)"
+      },
+      {
+        "index":false,
+        "name":"cmdline_size",
+        "required":false,
+        "hidden":true,
+        "type":"bigint",
+        "description":"Actual size (bytes) of command line arguments"
+      },
+      {
+        "index":false,
+        "name":"env",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"Environment variables delimited by spaces"
+      },
+      {
+        "index":false,
+        "name":"env_count",
+        "required":false,
+        "hidden":true,
+        "type":"bigint",
+        "description":"Number of environment variables"
+      },
+      {
+        "index":false,
+        "name":"env_size",
+        "required":false,
+        "hidden":true,
+        "type":"bigint",
+        "description":"Actual size (bytes) of environment list"
+      },
+      {
+        "index":false,
+        "name":"cwd",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The process current working directory"
+      },
+      {
+        "index":false,
+        "name":"auid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Audit User ID at process start"
+      },
+      {
+        "index":false,
+        "name":"uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"User ID at process start"
+      },
+      {
+        "index":false,
+        "name":"euid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Effective user ID at process start"
+      },
+      {
+        "index":false,
+        "name":"gid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Group ID at process start"
+      },
+      {
+        "index":false,
+        "name":"egid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Effective group ID at process start"
+      },
+      {
+        "index":false,
+        "name":"owner_uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"File owner user ID"
+      },
+      {
+        "index":false,
+        "name":"owner_gid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"File owner group ID"
+      },
+      {
+        "index":false,
+        "name":"atime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"File last access in UNIX time"
+      },
+      {
+        "index":false,
+        "name":"mtime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"File modification in UNIX time"
+      },
+      {
+        "index":false,
+        "name":"ctime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"File last metadata change in UNIX time"
+      },
+      {
+        "index":false,
+        "name":"btime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"File creation in UNIX time"
+      },
+      {
+        "index":false,
+        "name":"overflows",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"List of structures that overflowed"
+      },
+      {
+        "index":false,
+        "name":"parent",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Process parent's PID"
+      },
+      {
+        "index":false,
+        "name":"time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time of execution in UNIX time"
+      },
+      {
+        "index":false,
+        "name":"uptime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time of execution in system uptime"
+      },
+      {
+        "index":false,
+        "name":"status",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"OpenBSM Attribute: Status of the process"
+      },
+      {
+        "index":false,
+        "name":"eid",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"Event ID"
+      }
+    ],
+    "description":"Track time/action process executions."
+  },
+  {
+    "cacheable":false,
+    "evented":true,
+    "name":"process_file_events",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/kernel/process_file_events.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"action",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The action taken on the file (OPEN, CLOSED, or CLOSED_MODIFIED)"
+      },
+      {
+        "index":false,
+        "name":"pid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Process ID of the process using the file"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path of file"
+      },
+      {
+        "index":false,
+        "name":"parent",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Parent process ID of the process using the file"
+      },
+      {
+        "index":false,
+        "name":"uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Real user ID of the user process using the file"
+      },
+      {
+        "index":false,
+        "name":"euid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Effective user ID of the process using the file"
+      },
+      {
+        "index":false,
+        "name":"gid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Real group ID of the process using the file"
+      },
+      {
+        "index":false,
+        "name":"egid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Effective group ID of the processs using the file"
+      },
+      {
+        "index":false,
+        "name":"mode",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Indicates the mode of the file"
+      },
+      {
+        "index":false,
+        "name":"owner_uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"User ID of the owner of the file"
+      },
+      {
+        "index":false,
+        "name":"owner_gid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Group ID of the owner of the file"
+      },
+      {
+        "index":false,
+        "name":"atime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time of last access in UNIX epoch time"
+      },
+      {
+        "index":false,
+        "name":"mtime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time of last modification in UNIX epoch time"
+      },
+      {
+        "index":false,
+        "name":"ctime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time of last status change"
+      },
+      {
+        "index":false,
+        "name":"time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time of event in UNIX epoch time"
+      },
+      {
+        "index":false,
+        "name":"uptime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time of event in system uptime"
+      },
+      {
+        "index":false,
+        "name":"eid",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"Event ID"
+      }
+    ],
+    "description":"Process file events (open and close) from kernel extension."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"process_memory_map",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/process_memory_map.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"pid",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Process (or thread) ID"
+      },
+      {
+        "index":false,
+        "name":"start",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Virtual start address (hex)"
+      },
+      {
+        "index":false,
+        "name":"end",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Virtual end address (hex)"
+      },
+      {
+        "index":false,
+        "name":"permissions",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"r=read, w=write, x=execute, p=private (cow)"
+      },
+      {
+        "index":false,
+        "name":"offset",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Offset into mapped path"
+      },
+      {
+        "index":false,
+        "name":"device",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"MA:MI Major/minor device ID"
+      },
+      {
+        "index":false,
+        "name":"inode",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Mapped path inode, 0 means uninitialized (BSS)"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to mapped file or mapped type"
+      },
+      {
+        "index":false,
+        "name":"pseudo",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If path is a pseudo path, else 0"
+      }
+    ],
+    "description":"Process memory mapped files and pseudo device/regions."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"process_open_files",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/process_open_files.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"pid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Process (or thread) ID"
+      },
+      {
+        "index":false,
+        "name":"fd",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Process-specific file descriptor number"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Filesystem path of descriptor"
+      }
+    ],
+    "description":"File descriptors for each process."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"process_open_sockets",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/process_open_sockets.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"pid",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Process (or thread) ID"
+      },
+      {
+        "index":false,
+        "name":"fd",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Socket file descriptor number"
+      },
+      {
+        "index":false,
+        "name":"socket",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Socket handle or inode number"
+      },
+      {
+        "index":false,
+        "name":"family",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Network protocol (IPv4, IPv6)"
+      },
+      {
+        "index":false,
+        "name":"protocol",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Transport protocol (TCP/UDP)"
+      },
+      {
+        "index":false,
+        "name":"local_address",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Socket local address"
+      },
+      {
+        "index":false,
+        "name":"remote_address",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Socket remote address"
+      },
+      {
+        "index":false,
+        "name":"local_port",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Socket local port"
+      },
+      {
+        "index":false,
+        "name":"remote_port",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Socket remote port"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"For UNIX sockets (family=AF_UNIX), the domain path"
+      }
+    ],
+    "description":"Processes which have open network sockets on the system."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"processes",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/processes.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"pid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Process (or thread) ID"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The process path or shorthand argv[0]"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to executed binary"
+      },
+      {
+        "index":false,
+        "name":"cmdline",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Complete argv"
+      },
+      {
+        "index":false,
+        "name":"state",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Process state"
+      },
+      {
+        "index":false,
+        "name":"cwd",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Process current working directory"
+      },
+      {
+        "index":false,
+        "name":"root",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Process virtual root directory"
+      },
+      {
+        "index":false,
+        "name":"uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Unsigned user ID"
+      },
+      {
+        "index":false,
+        "name":"gid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Unsigned group ID"
+      },
+      {
+        "index":false,
+        "name":"euid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Unsigned effective user ID"
+      },
+      {
+        "index":false,
+        "name":"egid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Unsigned effective group ID"
+      },
+      {
+        "index":false,
+        "name":"suid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Unsigned saved user ID"
+      },
+      {
+        "index":false,
+        "name":"sgid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Unsigned saved group ID"
+      },
+      {
+        "index":false,
+        "name":"on_disk",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"The process path exists yes=1, no=0, unknown=-1"
+      },
+      {
+        "index":false,
+        "name":"wired_size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Bytes of unpagable memory used by process"
+      },
+      {
+        "index":false,
+        "name":"resident_size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Bytes of private memory used by process"
+      },
+      {
+        "index":false,
+        "name":"total_size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total virtual memory size"
+      },
+      {
+        "index":false,
+        "name":"user_time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"CPU time spent in user space"
+      },
+      {
+        "index":false,
+        "name":"system_time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"CPU time spent in kernel space"
+      },
+      {
+        "index":false,
+        "name":"start_time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Process start in seconds since boot (non-sleeping)"
+      },
+      {
+        "index":false,
+        "name":"parent",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Process parent's PID"
+      },
+      {
+        "index":false,
+        "name":"pgroup",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Process group"
+      },
+      {
+        "index":false,
+        "name":"threads",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of threads used by process"
+      },
+      {
+        "index":false,
+        "name":"nice",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Process nice level (-20 to 20, default 0)"
+      }
+    ],
+    "description":"All running processes on the host system."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"programs",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/windows/programs.table",
+    "platforms":[
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Commonly used product name."
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Product version information."
+      },
+      {
+        "index":false,
+        "name":"install_location",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The installation location directory of the product."
+      },
+      {
+        "index":false,
+        "name":"install_source",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The installation source of the product."
+      },
+      {
+        "index":false,
+        "name":"language",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The language of the product."
+      },
+      {
+        "index":false,
+        "name":"publisher",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the product supplier."
+      },
+      {
+        "index":false,
+        "name":"uninstall_string",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path and filename of the uninstaller."
+      },
+      {
+        "index":false,
+        "name":"install_date",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Date that this product was installed on the system. "
+      },
+      {
+        "index":false,
+        "name":"identifying_number",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Product identification such as a serial number on software, or a die number on a hardware chip."
+      }
+    ],
+    "description":"Represents products as they are installed by Windows Installer. A product generally correlates to one installation package on Windows. Some fields may be blank as Windows installation details are left to the discretion of the product author."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"prometheus_metrics",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/prometheus_metrics.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"target_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Address of prometheus target"
+      },
+      {
+        "index":false,
+        "name":"metric_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of collected Prometheus metric"
+      },
+      {
+        "index":false,
+        "name":"metric_value",
+        "required":false,
+        "hidden":false,
+        "type":"double",
+        "description":"Value of collected Prometheus metric"
+      },
+      {
+        "index":false,
+        "name":"timestamp_ms",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Unix timestamp of collected data in MS"
+      }
+    ],
+    "description":"Network interfaces and relevant metadata."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"python_packages",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/python_packages.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package display name"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package-supplied version"
+      },
+      {
+        "index":false,
+        "name":"summary",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package-supplied summary"
+      },
+      {
+        "index":false,
+        "name":"author",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Optional package author"
+      },
+      {
+        "index":false,
+        "name":"license",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"License under which package is launched"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path at which this module resides"
+      }
+    ],
+    "description":"Python packages installed in a system."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"quicklook_cache",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/quicklook_cache.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path of file"
+      },
+      {
+        "index":false,
+        "name":"rowid",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Quicklook file rowid key"
+      },
+      {
+        "index":false,
+        "name":"fs_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Quicklook file fs_id key"
+      },
+      {
+        "index":false,
+        "name":"volume_id",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Parsed volume ID from fs_id"
+      },
+      {
+        "index":false,
+        "name":"inode",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Parsed file ID (inode) from fs_id"
+      },
+      {
+        "index":false,
+        "name":"mtime",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Parsed version date field"
+      },
+      {
+        "index":false,
+        "name":"size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Parsed version size field"
+      },
+      {
+        "index":false,
+        "name":"label",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Parsed version 'gen' field"
+      },
+      {
+        "index":false,
+        "name":"last_hit_date",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Apple date format for last thumbnail cache hit"
+      },
+      {
+        "index":false,
+        "name":"hit_count",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Number of cache hits on thumbnail"
+      },
+      {
+        "index":false,
+        "name":"icon_mode",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Thumbnail icon mode"
+      },
+      {
+        "index":false,
+        "name":"cache_path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to cache data"
+      }
+    ],
+    "description":"Files and thumbnails within OS X's Quicklook Cache."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"registry",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/windows/registry.table",
+    "platforms":[
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"key",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the key to search for"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Full path to the value"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the registry value entry"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Type of the registry value, or 'subkey' if item is a subkey"
+      },
+      {
+        "index":false,
+        "name":"data",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Data content of registry value"
+      },
+      {
+        "index":false,
+        "name":"mtime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"timestamp of the most recent registry write"
+      }
+    ],
+    "description":"All of the Windows registry hives."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"routes",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/routes.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"destination",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Destination IP address"
+      },
+      {
+        "index":false,
+        "name":"netmask",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Netmask length"
+      },
+      {
+        "index":false,
+        "name":"gateway",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Route gateway"
+      },
+      {
+        "index":false,
+        "name":"source",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Route source"
+      },
+      {
+        "index":false,
+        "name":"flags",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Flags to describe route"
+      },
+      {
+        "index":false,
+        "name":"interface",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Route local interface"
+      },
+      {
+        "index":false,
+        "name":"mtu",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Maximum Transmission Unit for the route"
+      },
+      {
+        "index":false,
+        "name":"metric",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Cost of route. Lowest is preferred"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Type of route"
+      }
+    ],
+    "description":"The active route table for the host system."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"rpm_package_files",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/linux/rpm_package_files.table",
+    "platforms":[
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"package",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"RPM package name"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path name"
+      },
+      {
+        "index":false,
+        "name":"username",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"File default username from info DB"
+      },
+      {
+        "index":false,
+        "name":"groupname",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"File default groupname from info DB"
+      },
+      {
+        "index":false,
+        "name":"mode",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"File permissions mode from info DB"
+      },
+      {
+        "index":false,
+        "name":"size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Expected file size in bytes from RPM info DB"
+      },
+      {
+        "index":false,
+        "name":"sha256",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"SHA256 file digest from RPM info DB"
+      }
+    ],
+    "description":"RPM packages that are currently installed on the host system."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"rpm_packages",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/linux/rpm_packages.table",
+    "platforms":[
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"RPM package name"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package version"
+      },
+      {
+        "index":false,
+        "name":"release",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Package release"
+      },
+      {
+        "index":false,
+        "name":"source",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Source RPM package name (optional)"
+      },
+      {
+        "index":false,
+        "name":"size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Package size in bytes"
+      },
+      {
+        "index":false,
+        "name":"sha1",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"SHA1 hash of the package contents"
+      },
+      {
+        "index":false,
+        "name":"arch",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Architecture(s) supported"
+      }
+    ],
+    "description":"RPM packages that are currently installed on the host system."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"safari_extensions",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/safari_extensions.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The local user that owns the extension"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Extension display name"
+      },
+      {
+        "index":false,
+        "name":"identifier",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Extension identifier"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Extension long version"
+      },
+      {
+        "index":false,
+        "name":"sdk",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Bundle SDK used to compile extension"
+      },
+      {
+        "index":false,
+        "name":"update_url",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Extension-supplied update URI"
+      },
+      {
+        "index":false,
+        "name":"author",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Optional extension author"
+      },
+      {
+        "index":false,
+        "name":"developer_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Optional developer identifier"
+      },
+      {
+        "index":false,
+        "name":"description",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Optional extension description text"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to extension XAR bundle"
+      }
+    ],
+    "description":"Safari browser extension details for all users."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"sandboxes",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/sandboxes.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"label",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"UTI-format bundle or label ID"
+      },
+      {
+        "index":false,
+        "name":"user",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Sandbox owner"
+      },
+      {
+        "index":false,
+        "name":"enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Application sandboxings enabled on container"
+      },
+      {
+        "index":false,
+        "name":"build_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Sandbox-specific identifier"
+      },
+      {
+        "index":false,
+        "name":"bundle_path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Application bundle used by the sandbox"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to sandbox container directory"
+      }
+    ],
+    "description":"OS X application sandboxes container details."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"scheduled_tasks",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/windows/scheduled_tasks.table",
+    "platforms":[
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the scheduled task"
+      },
+      {
+        "index":false,
+        "name":"action",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Actions executed by the scheduled task"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to the executable to be run"
+      },
+      {
+        "index":false,
+        "name":"enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Whether or not the scheduled task is enabled"
+      },
+      {
+        "index":false,
+        "name":"state",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"State of the scheduled task"
+      },
+      {
+        "index":false,
+        "name":"hidden",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Whether or not the task is visible in the UI"
+      },
+      {
+        "index":false,
+        "name":"last_run_time",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Timestamp the task last ran"
+      },
+      {
+        "index":false,
+        "name":"next_run_time",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Timestamp the task is scheduled to run next"
+      },
+      {
+        "index":false,
+        "name":"last_run_message",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Exit status message of the last task run"
+      },
+      {
+        "index":false,
+        "name":"last_run_code",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Exit status code of the last task run"
+      }
+    ],
+    "description":"Lists all of the tasks in the Windows task scheduler."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"services",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/windows/services.table",
+    "platforms":[
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Service name"
+      },
+      {
+        "index":false,
+        "name":"service_type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Service Type: OWN_PROCESS, SHARE_PROCESS and maybe Interactive (can interact with the desktop)"
+      },
+      {
+        "index":false,
+        "name":"display_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Service Display name"
+      },
+      {
+        "index":false,
+        "name":"status",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Service Current status: STOPPED, START_PENDING, STOP_PENDING, RUNNING, CONTINUE_PENDING, PAUSE_PENDING, PAUSED"
+      },
+      {
+        "index":false,
+        "name":"pid",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"the Process ID of the service"
+      },
+      {
+        "index":false,
+        "name":"start_type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Service start type: BOOT_START, SYSTEM_START, AUTO_START, DEMAND_START, DISABLED"
+      },
+      {
+        "index":false,
+        "name":"win32_exit_code",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"The error code that the service uses to report an error that occurs when it is starting or stopping"
+      },
+      {
+        "index":false,
+        "name":"service_exit_code",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"The service-specific error code that the service returns when an error occurs while the service is starting or stopping"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to Service Executable"
+      },
+      {
+        "index":false,
+        "name":"module_path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to ServiceDll"
+      },
+      {
+        "index":false,
+        "name":"description",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Service Description"
+      },
+      {
+        "index":false,
+        "name":"user_account",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The name of the account that the service process will be logged on as when it runs. This name can be of the form Domain\\UserName. If the account belongs to the built-in domain, the name can be of the form .\\UserName."
+      }
+    ],
+    "description":"Lists all installed Windows services and their relevant data."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"shadow",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/linux/shadow.table",
+    "platforms":[
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"password_status",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Password status"
+      },
+      {
+        "index":false,
+        "name":"hash_alg",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Password hashing algorithm"
+      },
+      {
+        "index":false,
+        "name":"last_change",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Date of last password change (starting from UNIX epoch date)"
+      },
+      {
+        "index":false,
+        "name":"min",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Minimal number of days between password changes"
+      },
+      {
+        "index":false,
+        "name":"max",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Maximum number of days between password changes"
+      },
+      {
+        "index":false,
+        "name":"warning",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Number of days before password expires to warn user about it"
+      },
+      {
+        "index":false,
+        "name":"inactive",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Number of days after password expires until account is blocked"
+      },
+      {
+        "index":false,
+        "name":"expire",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Number of days since UNIX epoch date until account is disabled"
+      },
+      {
+        "index":false,
+        "name":"flag",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Reserved"
+      },
+      {
+        "index":false,
+        "name":"username",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Username"
+      }
+    ],
+    "description":"Local system users encrypted passwords and related information."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"shared_folders",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/shared_folders.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The shared name of the folder as it appears to other users"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Absolute path of shared folder on the local system"
+      }
+    ],
+    "description":"Folders available to others via SMB or AFP."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"shared_memory",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/linux/shared_memory.table",
+    "platforms":[
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"shmid",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Shared memory segment ID"
+      },
+      {
+        "index":false,
+        "name":"owner_uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"User ID of owning process"
+      },
+      {
+        "index":false,
+        "name":"creator_uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"User ID of creator process"
+      },
+      {
+        "index":false,
+        "name":"pid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Process ID to last use the segment"
+      },
+      {
+        "index":false,
+        "name":"creator_pid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Process ID that created the segment"
+      },
+      {
+        "index":false,
+        "name":"atime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Attached time"
+      },
+      {
+        "index":false,
+        "name":"dtime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Detached time"
+      },
+      {
+        "index":false,
+        "name":"ctime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Changed time"
+      },
+      {
+        "index":false,
+        "name":"permissions",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Memory segment permissions"
+      },
+      {
+        "index":false,
+        "name":"size",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Size in bytes"
+      },
+      {
+        "index":false,
+        "name":"attached",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of attached processes"
+      },
+      {
+        "index":false,
+        "name":"status",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Destination/attach status"
+      },
+      {
+        "index":false,
+        "name":"locked",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if segment is locked else 0"
+      }
+    ],
+    "description":"OS shared memory regions."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"shared_resources",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/windows/shared_resources.table",
+    "platforms":[
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"description",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"A textual description of the object"
+      },
+      {
+        "index":false,
+        "name":"install_date",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Indicates when the object was installed. Lack of a value does not indicate that the object is not installed."
+      },
+      {
+        "index":false,
+        "name":"status",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"String that indicates the current status of the object."
+      },
+      {
+        "index":false,
+        "name":"allow_maximum",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of concurrent users for this resource has been limited. If True, the value in the MaximumAllowed property is ignored."
+      },
+      {
+        "index":false,
+        "name":"maximum_allowed",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Limit on the maximum number of users allowed to use this resource concurrently. The value is only valid if the AllowMaximum property is set to FALSE."
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Alias given to a path set up as a share on a computer system running Windows."
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Local path of the Windows share."
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Type of resource being shared. Types include: disk drives, print queues, interprocess communications (IPC), and general devices."
+      }
+    ],
+    "description":"Displays shared resources on a computer system running Windows. This may be a disk drive, printer, interprocess communication, or other sharable device."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"sharing_preferences",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/sharing_preferences.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"screen_sharing",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If screen sharing is enabled else 0"
+      },
+      {
+        "index":false,
+        "name":"file_sharing",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If file sharing is enabled else 0"
+      },
+      {
+        "index":false,
+        "name":"printer_sharing",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If printer sharing is enabled else 0"
+      },
+      {
+        "index":false,
+        "name":"remote_login",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If remote login is enabled else 0"
+      },
+      {
+        "index":false,
+        "name":"remote_management",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If remote management is enabled else 0"
+      },
+      {
+        "index":false,
+        "name":"remote_apple_events",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If remote apple events are enabled else 0"
+      },
+      {
+        "index":false,
+        "name":"internet_sharing",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If internet sharing is enabled else 0"
+      },
+      {
+        "index":false,
+        "name":"bluetooth_sharing",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If bluetooth sharing is enabled for any user else 0"
+      },
+      {
+        "index":false,
+        "name":"disc_sharing",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If CD or DVD sharing is enabled else 0"
+      }
+    ],
+    "description":"OS X Sharing preferences."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"shell_history",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/shell_history.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Shell history owner"
+      },
+      {
+        "index":false,
+        "name":"time",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Entry timestamp"
+      },
+      {
+        "index":false,
+        "name":"command",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Unparsed date/line/command history line"
+      },
+      {
+        "index":false,
+        "name":"history_file",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to the .*_history for this user"
+      }
+    ],
+    "description":"A line-delimited (command) table of per-user .*_history data."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"signature",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/signature.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"path",
+        "required":true,
+        "hidden":false,
+        "type":"text",
+        "description":"Must provide a path or directory"
+      },
+      {
+        "index":false,
+        "name":"signed",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If the file is signed else 0"
+      },
+      {
+        "index":false,
+        "name":"identifier",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The signing identifier sealed into the signature"
+      },
+      {
+        "index":false,
+        "name":"cdhash",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"SHA1 hash of the application Code Directory"
+      },
+      {
+        "index":false,
+        "name":"team_identifier",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The team signing identifier sealed into the signature"
+      },
+      {
+        "index":false,
+        "name":"authority",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Certificate Common Name"
+      }
+    ],
+    "description":"File (executable, bundle, installer, disk) code signing status."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"sip_config",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/sip_config.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"config_flag",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The System Integrity Protection config flag"
+      },
+      {
+        "index":false,
+        "name":"enabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if this configuration is enabled, otherwise 0"
+      },
+      {
+        "index":false,
+        "name":"enabled_nvram",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if this configuration is enabled, otherwise 0"
+      }
+    ],
+    "description":"Apple's System Integrity Protection (rootless) status."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"smbios_tables",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/smbios_tables.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"number",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Table entry number"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Table entry type"
+      },
+      {
+        "index":false,
+        "name":"description",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Table entry description"
+      },
+      {
+        "index":false,
+        "name":"handle",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Table entry handle"
+      },
+      {
+        "index":false,
+        "name":"header_size",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Header size in bytes"
+      },
+      {
+        "index":false,
+        "name":"size",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Table entry size in bytes"
+      },
+      {
+        "index":false,
+        "name":"md5",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"MD5 hash of table entry"
+      }
+    ],
+    "description":"BIOS (DMI) structure common details and content."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"smc_keys",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/smc_keys.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"key",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"4-character key"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"SMC-reported type literal type"
+      },
+      {
+        "index":false,
+        "name":"size",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Reported size of data in bytes"
+      },
+      {
+        "index":false,
+        "name":"value",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"A type-encoded representation of the key value"
+      },
+      {
+        "index":false,
+        "name":"hidden",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if this key is normally hidden, otherwise 0"
+      }
+    ],
+    "description":"Apple's system management controller keys."
+  },
+  {
+    "cacheable":false,
+    "evented":true,
+    "name":"socket_events",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/linux/socket_events.table",
+    "platforms":[
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"action",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The socket action (bind, listen, close)"
+      },
+      {
+        "index":false,
+        "name":"pid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Process (or thread) ID"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path of executed file"
+      },
+      {
+        "index":false,
+        "name":"fd",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The file description for the process socket"
+      },
+      {
+        "index":false,
+        "name":"auid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Audit User ID"
+      },
+      {
+        "index":false,
+        "name":"success",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"The socket open attempt status"
+      },
+      {
+        "index":false,
+        "name":"family",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"The Internet protocol family ID"
+      },
+      {
+        "index":false,
+        "name":"protocol",
+        "required":false,
+        "hidden":true,
+        "type":"integer",
+        "description":"The network protocol ID"
+      },
+      {
+        "index":false,
+        "name":"local_address",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Local address associated with socket"
+      },
+      {
+        "index":false,
+        "name":"remote_address",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Remote address associated with socket"
+      },
+      {
+        "index":false,
+        "name":"local_port",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Local network protocol port number"
+      },
+      {
+        "index":false,
+        "name":"remote_port",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Remote network protocol port number"
+      },
+      {
+        "index":false,
+        "name":"socket",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"The local path (UNIX domain socket only)"
+      },
+      {
+        "index":false,
+        "name":"time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time of execution in UNIX time"
+      },
+      {
+        "index":false,
+        "name":"uptime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time of execution in system uptime"
+      },
+      {
+        "index":false,
+        "name":"eid",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"Event ID"
+      }
+    ],
+    "description":"Track network socket opens and closes."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"startup_items",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/startup_items.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of startup item"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path of startup item"
+      },
+      {
+        "index":false,
+        "name":"args",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Arguments provided to startup executable"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Startup Item or Login Item"
+      },
+      {
+        "index":false,
+        "name":"source",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Directory or plist containing startup item"
+      },
+      {
+        "index":false,
+        "name":"status",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Startup status; either enabled or disabled"
+      },
+      {
+        "index":false,
+        "name":"username",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The user associated with the startup item"
+      }
+    ],
+    "description":"Applications and binaries set as user/login startup items."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"sudoers",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/sudoers.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"header",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Symbol for given rule"
+      },
+      {
+        "index":false,
+        "name":"rule_details",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Rule definition"
+      }
+    ],
+    "description":"Rules for running commands as other users via sudo."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"suid_bin",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/suid_bin.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Binary path"
+      },
+      {
+        "index":false,
+        "name":"username",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Binary owner username"
+      },
+      {
+        "index":false,
+        "name":"groupname",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Binary owner group"
+      },
+      {
+        "index":false,
+        "name":"permissions",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Binary permissions"
+      }
+    ],
+    "description":"suid binaries in common locations."
+  },
+  {
+    "cacheable":false,
+    "evented":true,
+    "name":"syslog_events",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/linux/syslog_events.table",
+    "platforms":[
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Current unix epoch time"
+      },
+      {
+        "index":false,
+        "name":"datetime",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Time known to syslog"
+      },
+      {
+        "index":false,
+        "name":"host",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Hostname configured for syslog"
+      },
+      {
+        "index":false,
+        "name":"severity",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Syslog severity"
+      },
+      {
+        "index":false,
+        "name":"facility",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Syslog facility"
+      },
+      {
+        "index":false,
+        "name":"tag",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The syslog tag"
+      },
+      {
+        "index":false,
+        "name":"message",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The syslog message"
+      },
+      {
+        "index":false,
+        "name":"eid",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"Event ID"
+      }
+    ],
+    "description":""
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"system_controls",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/system_controls.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Full sysctl MIB name"
+      },
+      {
+        "index":false,
+        "name":"oid",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Control MIB"
+      },
+      {
+        "index":false,
+        "name":"subsystem",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Subsystem ID, control type"
+      },
+      {
+        "index":false,
+        "name":"current_value",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Value of setting"
+      },
+      {
+        "index":false,
+        "name":"config_value",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The MIB value set in /etc/sysctl.conf"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Data type"
+      }
+    ],
+    "description":"sysctl names, values, and settings information."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"system_info",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/system_info.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"hostname",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Network hostname including domain"
+      },
+      {
+        "index":false,
+        "name":"uuid",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Unique ID provided by the system"
+      },
+      {
+        "index":false,
+        "name":"cpu_type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"CPU type"
+      },
+      {
+        "index":false,
+        "name":"cpu_subtype",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"CPU subtype"
+      },
+      {
+        "index":false,
+        "name":"cpu_brand",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"CPU brand string, contains vendor and model"
+      },
+      {
+        "index":false,
+        "name":"cpu_physical_cores",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Max number of CPU physical cores"
+      },
+      {
+        "index":false,
+        "name":"cpu_logical_cores",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Max number of CPU logical cores"
+      },
+      {
+        "index":false,
+        "name":"physical_memory",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total physical memory in bytes"
+      },
+      {
+        "index":false,
+        "name":"hardware_vendor",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Hardware or board vendor"
+      },
+      {
+        "index":false,
+        "name":"hardware_model",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Hardware or board model"
+      },
+      {
+        "index":false,
+        "name":"hardware_version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Hardware or board version"
+      },
+      {
+        "index":false,
+        "name":"hardware_serial",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Device or board serial number"
+      },
+      {
+        "index":false,
+        "name":"computer_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Friendly computer name (optional)"
+      },
+      {
+        "index":false,
+        "name":"local_hostname",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Local hostname (optional)"
+      }
+    ],
+    "description":"System information for identification."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"temperature_sensors",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/temperature_sensors.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"key",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The SMC key on OS X"
+      },
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of temperature source"
+      },
+      {
+        "index":false,
+        "name":"celsius",
+        "required":false,
+        "hidden":false,
+        "type":"double",
+        "description":"Temperature in Celsius"
+      },
+      {
+        "index":false,
+        "name":"fahrenheit",
+        "required":false,
+        "hidden":false,
+        "type":"double",
+        "description":"Temperature in Fahrenheit"
+      }
+    ],
+    "description":"Machine's temperature sensors."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"time",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/utility/time.table",
+    "platforms":[
+      "darwin",
+      "linux",
+      "freebsd",
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"weekday",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Current weekday in the system"
+      },
+      {
+        "index":false,
+        "name":"year",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Current year in the system"
+      },
+      {
+        "index":false,
+        "name":"month",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Current month in the system"
+      },
+      {
+        "index":false,
+        "name":"day",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Current day in the system"
+      },
+      {
+        "index":false,
+        "name":"hour",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Current hour in the system"
+      },
+      {
+        "index":false,
+        "name":"minutes",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Current minutes in the system"
+      },
+      {
+        "index":false,
+        "name":"seconds",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Current seconds in the system"
+      },
+      {
+        "index":false,
+        "name":"timezone",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Current timezone in the system"
+      },
+      {
+        "index":false,
+        "name":"local_time",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Current local UNIX time in the system"
+      },
+      {
+        "index":false,
+        "name":"local_timezone",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Current local timezone in the system"
+      },
+      {
+        "index":false,
+        "name":"unix_time",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Current UNIX time in the system, converted to UTC if --utc enabled"
+      },
+      {
+        "index":false,
+        "name":"timestamp",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Current timestamp (log format) in the system"
+      },
+      {
+        "index":false,
+        "name":"datetime",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Current date and time (ISO format) in the system"
+      },
+      {
+        "index":false,
+        "name":"iso_8601",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Current time (ISO format) in the system"
+      }
+    ],
+    "description":"Track current date and time in the system."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"time_machine_backups",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/time_machine_backups.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"destination_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Time Machine destination ID"
+      },
+      {
+        "index":false,
+        "name":"backup_date",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Backup Date"
+      }
+    ],
+    "description":"Backups to drives using TimeMachine."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"time_machine_destinations",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/time_machine_destinations.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"alias",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Human readable name of drive"
+      },
+      {
+        "index":false,
+        "name":"destination_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Time Machine destination ID"
+      },
+      {
+        "index":false,
+        "name":"consistency_scan_date",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Consistency scan date"
+      },
+      {
+        "index":false,
+        "name":"root_volume_uuid",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Root UUID of backup volume"
+      },
+      {
+        "index":false,
+        "name":"bytes_available",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Bytes available on volume"
+      },
+      {
+        "index":false,
+        "name":"bytes_used",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Bytes used on volume"
+      },
+      {
+        "index":false,
+        "name":"encryption",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Last known encrypted state"
+      }
+    ],
+    "description":"Locations backed up to using Time Machine."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"uptime",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/uptime.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"days",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Days of uptime"
+      },
+      {
+        "index":false,
+        "name":"hours",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Hours of uptime"
+      },
+      {
+        "index":false,
+        "name":"minutes",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Minutes of uptime"
+      },
+      {
+        "index":false,
+        "name":"seconds",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Seconds of uptime"
+      },
+      {
+        "index":false,
+        "name":"total_seconds",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total uptime seconds"
+      }
+    ],
+    "description":"Track time passed since last boot."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"usb_devices",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/usb_devices.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"usb_address",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"USB Device used address"
+      },
+      {
+        "index":false,
+        "name":"usb_port",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"USB Device used port"
+      },
+      {
+        "index":false,
+        "name":"vendor",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"USB Device vendor string"
+      },
+      {
+        "index":false,
+        "name":"vendor_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Hex encoded USB Device vendor identifier"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"USB Device version number"
+      },
+      {
+        "index":false,
+        "name":"model",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"USB Device model string"
+      },
+      {
+        "index":false,
+        "name":"model_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Hex encoded USB Device model identifier"
+      },
+      {
+        "index":false,
+        "name":"serial",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"USB Device serial connection"
+      },
+      {
+        "index":false,
+        "name":"class",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"USB Device class"
+      },
+      {
+        "index":false,
+        "name":"subclass",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"USB Device subclass"
+      },
+      {
+        "index":false,
+        "name":"protocol",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"USB Device protocol"
+      },
+      {
+        "index":false,
+        "name":"removable",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 If USB device is removable else 0"
+      }
+    ],
+    "description":"USB devices that are actively plugged into the host system."
+  },
+  {
+    "cacheable":false,
+    "evented":true,
+    "name":"user_events",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/user_events.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"User ID"
+      },
+      {
+        "index":false,
+        "name":"auid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Audit User ID"
+      },
+      {
+        "index":false,
+        "name":"pid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Process (or thread) ID"
+      },
+      {
+        "index":false,
+        "name":"message",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Message from the event"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"The file description for the process socket"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Supplied path from event"
+      },
+      {
+        "index":false,
+        "name":"address",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The Internet protocol address or family ID"
+      },
+      {
+        "index":false,
+        "name":"terminal",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The network protocol ID"
+      },
+      {
+        "index":false,
+        "name":"time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time of execution in UNIX time"
+      },
+      {
+        "index":false,
+        "name":"uptime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time of execution in system uptime"
+      },
+      {
+        "index":false,
+        "name":"eid",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"Event ID"
+      }
+    ],
+    "description":"Track user events from the audit framework."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"user_groups",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/user_groups.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"User ID"
+      },
+      {
+        "index":false,
+        "name":"gid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Group ID"
+      }
+    ],
+    "description":"Local system user group relationships."
+  },
+  {
+    "cacheable":false,
+    "evented":true,
+    "name":"user_interaction_events",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/user_interaction_events.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time"
+      }
+    ],
+    "description":"Track user interaction events from macOS' event tapping framework."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"user_ssh_keys",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/posix/user_ssh_keys.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The local user that owns the key file"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path to key file"
+      },
+      {
+        "index":false,
+        "name":"encrypted",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if key is encrypted, 0 otherwise"
+      }
+    ],
+    "description":"Returns the private keys in the users ~/.ssh directory and whether or not they are encrypted."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"users",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/users.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"uid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"User ID"
+      },
+      {
+        "index":false,
+        "name":"gid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Group ID (unsigned)"
+      },
+      {
+        "index":false,
+        "name":"uid_signed",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"User ID as int64 signed (Apple)"
+      },
+      {
+        "index":false,
+        "name":"gid_signed",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Default group ID as int64 signed (Apple)"
+      },
+      {
+        "index":false,
+        "name":"username",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Username"
+      },
+      {
+        "index":false,
+        "name":"description",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Optional user description"
+      },
+      {
+        "index":false,
+        "name":"directory",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"User's home directory"
+      },
+      {
+        "index":false,
+        "name":"shell",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"User's configured default shell"
+      },
+      {
+        "index":false,
+        "name":"uuid",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"User's UUID (Apple)"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"Whether the account is roaming (domain), local, or a system profile"
+      }
+    ],
+    "description":"Local system users."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"virtual_memory_info",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/virtual_memory_info.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"free",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total number of free pages."
+      },
+      {
+        "index":false,
+        "name":"active",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total number of active pages."
+      },
+      {
+        "index":false,
+        "name":"inactive",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total number of inactive pages."
+      },
+      {
+        "index":false,
+        "name":"speculative",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total number of speculative pages."
+      },
+      {
+        "index":false,
+        "name":"throttled",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total number of throttled pages."
+      },
+      {
+        "index":false,
+        "name":"wired",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total number of wired down pages."
+      },
+      {
+        "index":false,
+        "name":"purgeable",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total number of purgeable pages."
+      },
+      {
+        "index":false,
+        "name":"faults",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total number of calls to vm_faults."
+      },
+      {
+        "index":false,
+        "name":"copy",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total number of copy-on-write pages."
+      },
+      {
+        "index":false,
+        "name":"zero_fill",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total number of zero filled pages."
+      },
+      {
+        "index":false,
+        "name":"reactivated",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total number of reactivated pages."
+      },
+      {
+        "index":false,
+        "name":"purged",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total number of purged pages."
+      },
+      {
+        "index":false,
+        "name":"file_backed",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total number of file backed pages."
+      },
+      {
+        "index":false,
+        "name":"anonymous",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total number of anonymous pages."
+      },
+      {
+        "index":false,
+        "name":"uncompressed",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total number of uncompressed pages."
+      },
+      {
+        "index":false,
+        "name":"compressor",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The number of pages used to store compressed VM pages."
+      },
+      {
+        "index":false,
+        "name":"decompressed",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The total number of pages that have been decompressed by the VM compressor."
+      },
+      {
+        "index":false,
+        "name":"compressed",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The total number of pages that have been compressed by the VM compressor."
+      },
+      {
+        "index":false,
+        "name":"page_ins",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The total number of requests for pages from a pager."
+      },
+      {
+        "index":false,
+        "name":"page_outs",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Total number of pages paged out."
+      },
+      {
+        "index":false,
+        "name":"swap_ins",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The total number of compressed pages that have been swapped out to disk."
+      },
+      {
+        "index":false,
+        "name":"swap_outs",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"The total number of compressed pages that have been swapped back in from disk."
+      }
+    ],
+    "description":"Darwin Virtual Memory statistics."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"wifi_networks",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/wifi_networks.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"ssid",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"SSID octets of the network"
+      },
+      {
+        "index":false,
+        "name":"network_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the network"
+      },
+      {
+        "index":false,
+        "name":"security_type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Type of security on this network"
+      },
+      {
+        "index":false,
+        "name":"last_connected",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Last time this netword was connected to as a unix_time"
+      },
+      {
+        "index":false,
+        "name":"passpoint",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if Passpoint is supported, 0 otherwise"
+      },
+      {
+        "index":false,
+        "name":"possibly_hidden",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if network is possibly a hidden network, 0 otherwise"
+      },
+      {
+        "index":false,
+        "name":"roaming",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if roaming is supported, 0 otherwise"
+      },
+      {
+        "index":false,
+        "name":"roaming_profile",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Describe the roaming profile, usually one of Single, Dual  or Multi"
+      },
+      {
+        "index":false,
+        "name":"captive_portal",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if this network has a captive portal, 0 otherwise"
+      },
+      {
+        "index":false,
+        "name":"auto_login",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if auto login is enabled, 0 otherwise"
+      },
+      {
+        "index":false,
+        "name":"temporarily_disabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if this network is temporarily disabled, 0 otherwise"
+      },
+      {
+        "index":false,
+        "name":"disabled",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"1 if this network is disabled, 0 otherwise"
+      }
+    ],
+    "description":"OS X known/remembered Wi-Fi networks list."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"wifi_status",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/wifi_status.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"interface",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the interface"
+      },
+      {
+        "index":false,
+        "name":"ssid",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"SSID octets of the network"
+      },
+      {
+        "index":false,
+        "name":"bssid",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The current basic service set identifier"
+      },
+      {
+        "index":false,
+        "name":"network_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the network"
+      },
+      {
+        "index":false,
+        "name":"country_code",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The country code (ISO/IEC 3166-1:1997) for the network"
+      },
+      {
+        "index":false,
+        "name":"security_type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Type of security on this network"
+      },
+      {
+        "index":false,
+        "name":"rssi",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"The current received signal strength indication (dbm)"
+      },
+      {
+        "index":false,
+        "name":"noise",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"The current noise measurement (dBm)"
+      },
+      {
+        "index":false,
+        "name":"channel",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Channel number"
+      },
+      {
+        "index":false,
+        "name":"channel_width",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Channel width"
+      },
+      {
+        "index":false,
+        "name":"channel_band",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Channel band"
+      },
+      {
+        "index":false,
+        "name":"transmit_rate",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The current transmit rate"
+      },
+      {
+        "index":false,
+        "name":"mode",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The current operating mode for the Wi-Fi interface"
+      }
+    ],
+    "description":"OS X current WiFi status."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"wifi_survey",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/wifi_scan.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"interface",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the interface"
+      },
+      {
+        "index":false,
+        "name":"ssid",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"SSID octets of the network"
+      },
+      {
+        "index":false,
+        "name":"bssid",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The current basic service set identifier"
+      },
+      {
+        "index":false,
+        "name":"network_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the network"
+      },
+      {
+        "index":false,
+        "name":"country_code",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The country code (ISO/IEC 3166-1:1997) for the network"
+      },
+      {
+        "index":false,
+        "name":"rssi",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"The current received signal strength indication (dbm)"
+      },
+      {
+        "index":false,
+        "name":"noise",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"The current noise measurement (dBm)"
+      },
+      {
+        "index":false,
+        "name":"channel",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Channel number"
+      },
+      {
+        "index":false,
+        "name":"channel_width",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Channel width"
+      },
+      {
+        "index":false,
+        "name":"channel_band",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Channel band"
+      }
+    ],
+    "description":"Scan for nearby WiFi networks."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"windows_crashes",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/windows/windows_crashes.table",
+    "platforms":[
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"datetime",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Timestamp (log format) of the crash"
+      },
+      {
+        "index":false,
+        "name":"module",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path of the crashed module within the process"
+      },
+      {
+        "index":false,
+        "name":"path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path of the executable file for the crashed process"
+      },
+      {
+        "index":false,
+        "name":"pid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Process ID of the crashed process"
+      },
+      {
+        "index":false,
+        "name":"tid",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Thread ID of the crashed thread"
+      },
+      {
+        "index":false,
+        "name":"version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"File version info of the crashed process"
+      },
+      {
+        "index":false,
+        "name":"process_uptime",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Uptime of the process in seconds"
+      },
+      {
+        "index":false,
+        "name":"stack_trace",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Multiple stack frames from the stack trace"
+      },
+      {
+        "index":false,
+        "name":"exception_code",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The Windows exception code"
+      },
+      {
+        "index":false,
+        "name":"exception_message",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The NTSTATUS error message associated with the exception code"
+      },
+      {
+        "index":false,
+        "name":"exception_address",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Address (in hex) where the exception occurred"
+      },
+      {
+        "index":false,
+        "name":"registers",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The values of the system registers"
+      },
+      {
+        "index":false,
+        "name":"command_line",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Command-line string passed to the crashed process"
+      },
+      {
+        "index":false,
+        "name":"current_directory",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Current working directory of the crashed process"
+      },
+      {
+        "index":false,
+        "name":"username",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Username of the user who ran the crashed process"
+      },
+      {
+        "index":false,
+        "name":"machine_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the machine where the crash happened"
+      },
+      {
+        "index":false,
+        "name":"major_version",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Windows major version of the machine"
+      },
+      {
+        "index":false,
+        "name":"minor_version",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Windows minor version of the machine"
+      },
+      {
+        "index":false,
+        "name":"build_number",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Windows build number of the crashing machine"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Type of crash log"
+      },
+      {
+        "index":false,
+        "name":"crash_path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Path of the log file"
+      }
+    ],
+    "description":"Extracted information from Windows crash logs (Minidumps)."
+  },
+  {
+    "cacheable":false,
+    "evented":true,
+    "name":"windows_events",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/windows/windows_events.table",
+    "platforms":[
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Timestamp the event was received"
+      },
+      {
+        "index":false,
+        "name":"datetime",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"System time at which the event occurred"
+      },
+      {
+        "index":false,
+        "name":"source",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Source or channel of the event"
+      },
+      {
+        "index":false,
+        "name":"provider_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Provider name of the event"
+      },
+      {
+        "index":false,
+        "name":"provider_guid",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Provider guid of the event"
+      },
+      {
+        "index":false,
+        "name":"eventid",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Event ID of the event"
+      },
+      {
+        "index":false,
+        "name":"task",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Task value associated with the event"
+      },
+      {
+        "index":false,
+        "name":"level",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"The severity level associated with the event"
+      },
+      {
+        "index":false,
+        "name":"keywords",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"A bitmask of the keywords defined in the event"
+      },
+      {
+        "index":false,
+        "name":"data",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Data associated with the event"
+      },
+      {
+        "index":false,
+        "name":"eid",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"Event ID"
+      }
+    ],
+    "description":"Windows Event logs."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"wmi_cli_event_consumers",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/windows/wmi_cli_event_consumers.table",
+    "platforms":[
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Unique name of a consumer."
+      },
+      {
+        "index":false,
+        "name":"command_line_template",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Standard string template that specifies the process to be started. This property can be NULL, and the ExecutablePath property is used as the command line."
+      },
+      {
+        "index":false,
+        "name":"executable_path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Module to execute. The string can specify the full path and file name of the module to execute, or it can specify a partial name. If a partial name is specified, the current drive and current directory are assumed."
+      },
+      {
+        "index":false,
+        "name":"class",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The name of the class."
+      },
+      {
+        "index":false,
+        "name":"relative_path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Relative path to the class or instance."
+      }
+    ],
+    "description":"WMI CommandLineEventConsumer, which can be used for persistance on Windows. See https://www.blackhat.com/docs/us-15/materials/us-15-Graeber-Abusing-Windows-Management-Instrumentation-WMI-To-Build-A-Persistent%20Asynchronous-And-Fileless-Backdoor-wp.pdf for more details."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"wmi_event_filters",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/windows/wmi_event_filters.table",
+    "platforms":[
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Unique identifier of an event filter."
+      },
+      {
+        "index":false,
+        "name":"query",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Windows Management Instrumentation Query Language (WQL) event query that specifies the set of events for consumer notification, and the specific conditions for notification."
+      },
+      {
+        "index":false,
+        "name":"query_language",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Query language that the query is written in."
+      },
+      {
+        "index":false,
+        "name":"class",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The name of the class."
+      },
+      {
+        "index":false,
+        "name":"relative_path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Relative path to the class or instance."
+      }
+    ],
+    "description":"Lists WMI event filters."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"wmi_filter_consumer_binding",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/windows/wmi_filter_consumer_binding.table",
+    "platforms":[
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"consumer",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Reference to an instance of __EventConsumer that represents the object path to a logical consumer, the recipient of an event."
+      },
+      {
+        "index":false,
+        "name":"filter",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Reference to an instance of __EventFilter that represents the object path to an event filter which is a query that specifies the type of event to be received."
+      },
+      {
+        "index":false,
+        "name":"class",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The name of the class."
+      },
+      {
+        "index":false,
+        "name":"relative_path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Relative path to the class or instance."
+      }
+    ],
+    "description":"Lists the relationship between event consumers and filters."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"wmi_script_event_consumers",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/windows/wmi_script_event_consumers.table",
+    "platforms":[
+      "windows"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Unique identifier for the event consumer. "
+      },
+      {
+        "index":false,
+        "name":"scripting_engine",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the scripting engine to use, for example, 'VBScript'. This property cannot be NULL."
+      },
+      {
+        "index":false,
+        "name":"script_file_name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Name of the file from which the script text is read, intended as an alternative to specifying the text of the script in the ScriptText property."
+      },
+      {
+        "index":false,
+        "name":"script_text",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Text of the script that is expressed in a language known to the scripting engine. This property must be NULL if the ScriptFileName property is not NULL."
+      },
+      {
+        "index":false,
+        "name":"class",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The name of the class."
+      },
+      {
+        "index":false,
+        "name":"relative_path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Relative path to the class or instance."
+      }
+    ],
+    "description":"WMI ActiveScriptEventConsumer, which can be used for persistance on Windows. See https://www.blackhat.com/docs/us-15/materials/us-15-Graeber-Abusing-Windows-Management-Instrumentation-WMI-To-Build-A-Persistent%20Asynchronous-And-Fileless-Backdoor-wp.pdf for more details."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"xprotect_entries",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/xprotect_entries.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Description of XProtected malware"
+      },
+      {
+        "index":false,
+        "name":"launch_type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Launch services content type"
+      },
+      {
+        "index":false,
+        "name":"identity",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"XProtect identity (SHA1) of content"
+      },
+      {
+        "index":false,
+        "name":"filename",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Use this file name to match"
+      },
+      {
+        "index":false,
+        "name":"filetype",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Use this file type to match"
+      },
+      {
+        "index":false,
+        "name":"optional",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Match any of the identities/patterns for this XProtect name"
+      },
+      {
+        "index":false,
+        "name":"uses_pattern",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Uses a match pattern instead of identity"
+      }
+    ],
+    "description":"Database of the machine's XProtect signatures."
+  },
+  {
+    "cacheable":true,
+    "evented":false,
+    "name":"xprotect_meta",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/xprotect_meta.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"identifier",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Browser plugin or extension identifier"
+      },
+      {
+        "index":false,
+        "name":"type",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Either plugin or extension"
+      },
+      {
+        "index":false,
+        "name":"developer_id",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Developer identity (SHA1) of extension"
+      },
+      {
+        "index":false,
+        "name":"min_version",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The minimum allowed plugin version."
+      }
+    ],
+    "description":"Database of the machine's XProtect browser-related signatures."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"xprotect_reports",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/darwin/xprotect_reports.table",
+    "platforms":[
+      "darwin"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"name",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Description of XProtected malware"
+      },
+      {
+        "index":false,
+        "name":"user_action",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Action taken by user after prompted"
+      },
+      {
+        "index":false,
+        "name":"time",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Quarantine alert time"
+      }
+    ],
+    "description":"Database of XProtect matches (if user generated/sent an XProtect report)."
+  },
+  {
+    "cacheable":false,
+    "evented":false,
+    "name":"yara",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/yara/yara.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"path",
+        "required":true,
+        "hidden":false,
+        "type":"text",
+        "description":"The path scanned"
+      },
+      {
+        "index":false,
+        "name":"matches",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"List of YARA matches"
+      },
+      {
+        "index":false,
+        "name":"count",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of YARA matches"
+      },
+      {
+        "index":false,
+        "name":"sig_group",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Signature group used"
+      },
+      {
+        "index":false,
+        "name":"sigfile",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Signature file used"
+      },
+      {
+        "index":false,
+        "name":"strings",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Matching strings"
+      },
+      {
+        "index":false,
+        "name":"tags",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Matching tags"
+      }
+    ],
+    "description":"Track YARA matches for files or PIDs."
+  },
+  {
+    "cacheable":false,
+    "evented":true,
+    "name":"yara_events",
+    "url":"https://github.com/facebook/osquery/blob/master/specs/yara/yara_events.table",
+    "platforms":[
+      "darwin",
+      "linux"
+    ],
+    "columns":[
+      {
+        "index":false,
+        "name":"target_path",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The path scanned"
+      },
+      {
+        "index":false,
+        "name":"category",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"The category of the file"
+      },
+      {
+        "index":false,
+        "name":"action",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Change action (UPDATE, REMOVE, etc)"
+      },
+      {
+        "index":false,
+        "name":"transaction_id",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"ID used during bulk update"
+      },
+      {
+        "index":false,
+        "name":"matches",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"List of YARA matches"
+      },
+      {
+        "index":false,
+        "name":"count",
+        "required":false,
+        "hidden":false,
+        "type":"integer",
+        "description":"Number of YARA matches"
+      },
+      {
+        "index":false,
+        "name":"strings",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Matching strings"
+      },
+      {
+        "index":false,
+        "name":"tags",
+        "required":false,
+        "hidden":false,
+        "type":"text",
+        "description":"Matching tags"
+      },
+      {
+        "index":false,
+        "name":"time",
+        "required":false,
+        "hidden":false,
+        "type":"bigint",
+        "description":"Time of the scan"
+      },
+      {
+        "index":false,
+        "name":"eid",
+        "required":false,
+        "hidden":true,
+        "type":"text",
+        "description":"Event ID"
+      }
+    ],
+    "description":"Track YARA matches for files specified in configuration data."
   }
-}
+]


### PR DESCRIPTION
It looks like we over-wrote the 2.11.2 schema data with the updated 2.11.2 package data in commit cd51799. We're reverting that commit and creating a new commit that updates the 2.11.2 package data w/ the Windows package.