### PR TITLE
Use lodash methods for values and keys

### DIFF
--- a/src/pages/Downloads/Downloads.js
+++ b/src/pages/Downloads/Downloads.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import { withRouter } from 'react-router'
+import { keys, values } from 'lodash'
 
 import content from 'data/pages/downloads.json'
 import DownloadCard from 'components/DownloadCard'
@@ -27,8 +28,8 @@ const installOptionNames = {
   freebsd: 'FreeBSD',
   windows: 'Windows',
 }
-const installOptionNamesKeys = Object.keys(installOptionNames)
-const installOptionNamesValues = Object.values(installOptionNames)
+const installOptionNamesKeys = keys(installOptionNames)
+const installOptionNamesValues = values(installOptionNames)
 
 class Downloads extends Component {
   state = {


### PR DESCRIPTION
IE and Safari <= 10.1 [don't support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values) `Object.values`. Replacing with lodash method. `Object.keys` is more widely accepted; using lodash for that method only for consistency.