### PR TITLE
Minor tweak to Osquery Events copy.

### DIFF
--- a/src/data/pages/home.json
+++ b/src/data/pages/home.json
@@ -26,7 +26,7 @@
     "communityEvents": {
       "sectionHeading": "Upcoming Community Events",
       "sectionSubHeading": "See events related to Osquery that are being held in the near future.",
-      "subSection1Heading": "Events are listed in reverse chronological by date"
+      "subSection1Heading": "Events are listed in reverse chronological order by date"
     },
     "communityProjects": {
       "sectionHeading": "Featured Community Projects",


### PR DESCRIPTION
Noticed a small omission error in the copy of the `Osquery Events` section, this PR corrects that sentence.