### PR TITLE
Don't cache service worker file

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,3 @@
+/service-worker.js
+  Cache-Control: no-cache
+  Max-Age: 0


### PR DESCRIPTION
https://github.com/facebook/create-react-app/issues/2440

This should resolve an issue where `index.html` is cached and pointing
at an invalid JavaScript bundle.