### PR TITLE
Copy and paste from Terminal body removes leader

### DIFF
--- a/src/components/terminals/TerminalBody/TerminalBody.js
+++ b/src/components/terminals/TerminalBody/TerminalBody.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Component } from 'react'
 import classnames from 'classnames'
 import { node, string } from 'prop-types'
 
@@ -6,15 +6,36 @@ import './TerminalBody.css'
 
 const baseClass = 'terminal-body'
 
-const TerminalBody = ({ children, className }) => {
-  const classNames = classnames(baseClass, className)
+class TerminalBody extends Component {
+  static propTypes = {
+    children: node.isRequired,
+    className: string,
+  }
 
-  return <div className={classNames}>{children}</div>
-}
+  componentDidMount() {
+    document.addEventListener('copy', this.formatCopy)
+  }
 
-TerminalBody.propTypes = {
-  children: node.isRequired,
-  className: string,
+  componentWillUnmount() {
+    document.removeEventListener('copy', this.formatCopy)
+  }
+
+  formatCopy = event => {
+    const selection = window.getSelection().toString()
+    if (event.target.closest(`.${baseClass}`)) {
+      const terminalLeader = /(^\$\s*|(?<=\n)\$\s*)/g
+
+      event.clipboardData.setData('text/plain', selection.replace(terminalLeader, ''))
+      event.preventDefault()
+    }
+  }
+
+  render() {
+    const { children, className } = this.props
+    const classNames = classnames(baseClass, className)
+
+    return <div className={classNames}>{children}</div>
+  }
 }
 
 export default TerminalBody


### PR DESCRIPTION
Removes the `$ ` leader at the beginning of each line when copying and pasting.

![mar-09-2018 15-16-45](https://user-images.githubusercontent.com/311215/37227961-f5630d8a-23ac-11e8-9a86-24880504dc9e.gif)

close #50