### PR TITLE
Add script to rebuild node-sass on postinstall step

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "watch-css": "npm run build-css && node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/ --watch --recursive",
     "build-css": "node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/",
     "lint": "eslint src",
+    "postinstall": "npm rebuild node-sass",
     "test": "node scripts/test.js --env=jsdom",
     "storybook": "start-storybook -p 9001 -c .storybook"
   },


### PR DESCRIPTION
There's a bug w/ node-sass which requires us to rebuild it on each install.