### PR TITLE
Break to column view earlier in resources section

### DIFF
--- a/src/pages/Home/Home.scss
+++ b/src/pages/Home/Home.scss
@@ -272,7 +272,7 @@
   margin: 50px auto 0;
   max-width: 1000px;
 
-  @media(max-width: $mobile-width) {
+  @media(max-width: 970px) {
     flex-direction: column;
   }
 }


### PR DESCRIPTION
The large circle call to action links for additional resources (slack, docs, github) on the home page were extending past the viewport width on smaller widths. This caused a horizontal scroll. This commit switches the links to column view before causing the scroll.

Resolves #57 