### PR TITLE
Blog post: fix images in mobile view

### DIFF
--- a/src/components/BlogPost/BlogPost.scss
+++ b/src/components/BlogPost/BlogPost.scss
@@ -40,6 +40,10 @@
       line-height: 1.56;
       font-size: 18px;
 
+      @media(max-width: $mobile-width) {
+        font-size: 16px;
+      }
+
       code {
         background-color: $pale-gray;
         box-sizing: border-box;
@@ -64,12 +68,24 @@
       }
     }
 
-    ul {
+    p > img:first-child {
+      display: block;
+      height: auto;
+      margin: 0 auto;
+      max-width: 90%;
+    }
+
+    ul, ol {
       color: rgba($gray, .8);
       font-size: 18px;
       margin-left: 42px;
 
+      @media(max-width: $mobile-width) {
+        font-size: 16px;
+      }
+
       li {
+        color: rgba($gray, .8);
         line-height: 1.56;
         margin-bottom: 20px;
 

--- a/src/pages/BlogShow/BlogShow.scss
+++ b/src/pages/BlogShow/BlogShow.scss
@@ -3,8 +3,3 @@
   display: flex;
   flex-direction: column;
 }
-
-.blog-show p img:first-child {
-  display: block;
-  margin: 0 auto;
-}


### PR DESCRIPTION
Sets a max width on images so that they shrink to fit on mobile. Refactors CSS into a better place.

Also brings font size down to 16px at smaller resolutions, and fixes formatting of ordered lists.

<img width="335" alt="screenshot 2018-05-30 13 38 50" src="https://user-images.githubusercontent.com/311215/40737722-93715e76-640f-11e8-95ab-7f1b9f9398c1.png">

<img width="333" alt="screenshot 2018-05-30 13 38 58" src="https://user-images.githubusercontent.com/311215/40737720-92ef9418-640f-11e8-8ec6-00cffc49b2ef.png">

<img width="349" alt="screenshot 2018-05-30 13 41 09" src="https://user-images.githubusercontent.com/311215/40737719-92ddf50a-640f-11e8-9976-babd857861de.png">
