### PR TITLE
Fix issue in which header would sometimes overlap TOC

### DIFF
--- a/src/pages/Schema/Schema.js
+++ b/src/pages/Schema/Schema.js
@@ -17,6 +17,7 @@ import schemaVersionExists from 'helpers/schema_version_exists'
 import throttle from 'helpers/throttle'
 import './Schema.css'
 
+const HEADER_HEIGHT = 80
 const baseClass = 'schema'
 const currentOsqueryVersion = osqueryVersionsData.current_version
 let tocOffset
@@ -56,9 +57,6 @@ class Schema extends Component {
       setTimeout(() => this.setActiveTable(this.props.location.hash.replace('#', '')), 100)
     }
 
-    const tocElement = document.getElementById(`${baseClass}-toc`)
-    tocOffset = tocElement ? tocElement.offsetTop : 0
-
     window.addEventListener('scroll', this.scrollActiveTable)
     window.addEventListener('scroll', this.stickyTOC)
   }
@@ -75,6 +73,10 @@ class Schema extends Component {
   componentWillUnmount() {
     window.removeEventListener('scroll', this.scrollActiveTable)
     window.removeEventListener('scroll', this.stickyTOC)
+  }
+
+  get headerIsVisible() {
+    return global.window.scrollY < HEADER_HEIGHT
   }
 
   getNormalizedSchemaVersion = schemaVersion => {
@@ -196,9 +198,11 @@ class Schema extends Component {
   }
 
   stickyTOC = throttle(() => {
-    if (tocOffset >= global.window.scrollY && this.state.fixedTOC)
+    if (this.headerIsVisible && this.state.fixedTOC) {
       this.setState({ fixedTOC: false })
-    if (tocOffset < global.window.scrollY && !this.state.fixedTOC) this.setState({ fixedTOC: true })
+    } else if (!this.headerIsVisible && !this.state.fixedTOC) {
+      this.setState({ fixedTOC: true })
+    }
   }, 10)
 
   filterTables = () => {
@@ -228,7 +232,7 @@ class Schema extends Component {
     })
 
     return (
-      <div className={classes} id={`${baseClass}-toc`}>
+      <div className={classes}>
         <h2 className={`${baseClass}__toc-header`}>
           <span className={`${baseClass}__tables-count`}>{this.state.tables.length}</span>
           {`Table${this.state.tables.length > 1 ? 's' : ''}`}

--- a/src/pages/Schema/Schema.js
+++ b/src/pages/Schema/Schema.js
@@ -79,6 +79,28 @@ class Schema extends Component {
     return global.window.scrollY < HEADER_HEIGHT
   }
 
+  get humanFriendlyPlatforms() {
+    if (this.selectedPlatforms().length === Object.entries(this.state.platforms).length)
+      return 'All platforms'
+
+    return this.selectedPlatforms()
+      .join(', ')
+      .replace('darwin', 'macOS')
+      .replace('freebsd', 'FreeBSD')
+      .replace('linux', 'Linux')
+      .replace('windows', 'Windows')
+  }
+
+  get pluralizedTables() {
+    const { tables } = this.state
+
+    if (tables.length === 1) {
+      return 'Table'
+    } else {
+      return 'Tables'
+    }
+  }
+
   getNormalizedSchemaVersion = schemaVersion => {
     return schemaVersion === 'current' ? currentOsqueryVersion : schemaVersion
   }
@@ -89,18 +111,6 @@ class Schema extends Component {
     } else {
       return require(`data/osquery_schema_versions/${schemaVersion}`)
     }
-  }
-
-  humanFriendlyPlatforms = () => {
-    if (this.selectedPlatforms().length === Object.entries(this.state.platforms).length)
-      return 'All platforms'
-
-    return this.selectedPlatforms()
-      .join(', ')
-      .replace('darwin', 'macOS')
-      .replace('freebsd', 'FreeBSD')
-      .replace('linux', 'Linux')
-      .replace('windows', 'Windows')
   }
 
   onPlatformChange = platforms => {
@@ -235,7 +245,7 @@ class Schema extends Component {
       <div className={classes}>
         <h2 className={`${baseClass}__toc-header`}>
           <span className={`${baseClass}__tables-count`}>{this.state.tables.length}</span>
-          {`Table${this.state.tables.length > 1 ? 's' : ''}`}
+          {this.pluralizedTables}
         </h2>
 
         <SchemaTOC
@@ -280,7 +290,7 @@ class Schema extends Component {
                   onChange={this.onPlatformChange}
                   platforms={this.state.platforms}
                 >
-                  {this.humanFriendlyPlatforms()}
+                  {this.humanFriendlyPlatforms}
                 </PlatformDropdown>
               </div>
 

--- a/src/pages/Schema/Schema.js
+++ b/src/pages/Schema/Schema.js
@@ -20,7 +20,6 @@ import './Schema.css'
 const HEADER_HEIGHT = 80
 const baseClass = 'schema'
 const currentOsqueryVersion = osqueryVersionsData.current_version
-let tocOffset
 
 class Schema extends Component {
   static propTypes = {


### PR DESCRIPTION
Simplifies the logic for the sticky TOC: if the header is visible, set the TOC to static. If the header isn't visible, fix the TOC to the upper corner.

![toc-scroll](https://user-images.githubusercontent.com/311215/40805322-e59c51d8-64eb-11e8-86e7-2ec2941d8eec.gif)

Fixes #69 

