### PR TITLE
Update version JSON to build implicit download URL to reduce human copy/paste errors

### DIFF
--- a/src/components/DownloadCard/DownloadCard.js
+++ b/src/components/DownloadCard/DownloadCard.js
@@ -30,7 +30,6 @@ const NameSection = ({ packageName, type, url }) => {
 }
 
 const DownloadCard = ({ className, downloadData, urlBase }) => {
-  console.log('downloadData', downloadData)
   const wrapperClassName = classnames(baseClass, className)
   const url = `${urlBase}/${downloadData.platform}/${downloadData.package}`
 

--- a/src/components/DownloadCard/DownloadCard.js
+++ b/src/components/DownloadCard/DownloadCard.js
@@ -29,21 +29,17 @@ const NameSection = ({ packageName, type, url }) => {
   )
 }
 
-const DownloadCard = ({ className, downloadData }) => {
+const DownloadCard = ({ className, downloadData, urlBase }) => {
+  console.log('downloadData', downloadData)
   const wrapperClassName = classnames(baseClass, className)
+  const url = `${urlBase}/${downloadData.platform}/${downloadData.package}`
 
   return (
     <GithubCard
       className={wrapperClassName}
       description={downloadData.content}
-      name={
-        <NameSection
-          packageName={downloadData.package}
-          type={downloadData.type}
-          url={downloadData.url}
-        />
-      }
-      url={downloadData.url}
+      name={<NameSection packageName={downloadData.package} type={downloadData.type} url={url} />}
+      url={url}
       urlText={`Download for ${downloadData.type}`}
     />
   )

--- a/src/data/osquery_package_versions/2.10.0.json
+++ b/src/data/osquery_package_versions/2.10.0.json
@@ -1,30 +1,31 @@
 {
   "version": "2.10.0",
+  "url": "https://pkg.osquery.io",
   "downloads": {
     "official": [
       {
         "type": "macOS",
         "package": "osquery-2.10.0.pkg",
         "content": "b30499ed09ddf649d6c49b49413b71e57183e786f82e65f2b8234e1a10d4ebf7",
-        "url": "https://pkg.osquery.io/darwin/osquery-2.10.0.pkg"
+        "platform": "darwin"
       },
       {
         "type": "Linux",
         "package": "osquery-2.10.0_1.linux_x86_64.tar.gz",
         "content": "dddceec84c002c46dd3cf2bc009dc8df4430e052631ff519b4665222ec018eb8",
-        "url": "https://pkg.osquery.io/linux/osquery-2.10.0_1.linux_x86_64.tar.gz"
+        "platform": "linux"
       },
       {
         "type": "RPM",
         "package": "osquery-2.10.0-1.linux.x86_64.rpm",
         "content": "501d9f79d5be09b901441109c9fd6d1fcbcf4fd0deb85a4d7abca3565ad0e9cf",
-        "url": "https://pkg.osquery.io/rpm/osquery-2.10.0-1.linux.x86_64.rpm"
+        "platform": "rpm"
       },
       {
         "type": "Debian",
         "package": "osquery_2.10.0_1.linux.amd64.deb",
         "content": "2b5eb496696420ec008e7d85a9c5555d3ea89fe56757cdec951730b9a2b58a93",
-        "url": "https://pkg.osquery.io/deb/osquery_2.10.0_1.linux.amd64.deb"
+        "platform": "deb"
       }
     ],
     "debug": [
@@ -32,19 +33,19 @@
         "type": "macOS",
         "package": "osquery-debug-2.10.0.pkg",
         "content": "1b4d3a739e4a398b33b7ad2e417d20b961feec6e328830d80de73a76ed8df940",
-        "url": "https://pkg.osquery.io/darwin/osquery-debug-2.10.0.pkg"
+        "platform": "darwin"
       },
       {
         "type": "RPM",
         "package": "osquery-debuginfo-2.10.0-1.linux.x86_64.rpm",
         "content": "95e23b3ea710d85260e4aea1f8fab71c9c8f1dfe0dec5b21ed5439cf3ba4bcce",
-        "url": "https://pkg.osquery.io/rpm/osquery-debuginfo-2.10.0-1.linux.x86_64.rpm"
+        "platform": "rpm/"
       },
       {
         "type": "Debian",
         "package": "osquery-dbg_2.10.2_1.linux.amd64.deb",
         "content": "33f7752206e15b44c3f5d17b24197d6e86b7b085c7030902e2e7bc4b5a81af1e",
-        "url": "https://pkg.osquery.io/deb/osquery-dbg_2.10.0_1.linux.amd64.deb"
+        "platform": "deb"
       }
     ]
   }

--- a/src/data/osquery_package_versions/2.10.0.json
+++ b/src/data/osquery_package_versions/2.10.0.json
@@ -39,7 +39,7 @@
         "type": "RPM",
         "package": "osquery-debuginfo-2.10.0-1.linux.x86_64.rpm",
         "content": "95e23b3ea710d85260e4aea1f8fab71c9c8f1dfe0dec5b21ed5439cf3ba4bcce",
-        "platform": "rpm/"
+        "platform": "rpm"
       },
       {
         "type": "Debian",

--- a/src/data/osquery_package_versions/2.10.2.json
+++ b/src/data/osquery_package_versions/2.10.2.json
@@ -1,30 +1,31 @@
 {
   "version": "2.10.2",
+  "url": "https://pkg.osquery.io",
   "downloads": {
     "official": [
       {
         "type": "macOS",
         "package": "osquery-2.10.2.pkg",
         "content": "3251f677b4735b37aa29b685225bc87aa4d906912432a595753517f298edc472",
-        "url": "https://pkg.osquery.io/darwin/osquery-2.10.2.pkg"
+        "platform": "darwin"
       },
       {
         "type": "Linux",
         "package": "osquery-2.10.2_1.linux_x86_64.tar.gz",
         "content": "7871ad268bccc9a84760c365ce3f1d1832ef75e06d5d27273cb6237980c50d43",
-        "url": "https://pkg.osquery.io/linux/osquery-2.10.2_1.linux_x86_64.tar.gz"
+        "platform": "linux"
       },
       {
         "type": "RPM",
         "package": "osquery-2.10.2-1.linux.x86_64.rpm",
         "content": "32d719fab707ce26bf8fde90fe0e17fb23c9c4ccd47e0917856aece8356a46c8",
-        "url": "https://pkg.osquery.io/rpm/osquery-2.10.2-1.linux.x86_64.rpm"
+        "platform": "rpm"
       },
       {
         "type": "Debian",
         "package": "osquery_2.10.2_1.linux.amd64.deb",
         "content": "29cf0e55d79021397d999472f619f1733b186167db30480e9015dad54211d157",
-        "url": "https://pkg.osquery.io/deb/osquery_2.10.2_1.linux.amd64.deb"
+        "platform": "deb"
       }
     ],
     "debug": [
@@ -32,19 +33,19 @@
         "type": "macOS",
         "package": "osquery-debug-2.10.2.pkg",
         "content": "9c7b5e3ffd2082556feff124e4ac2658f2706e44edf9885d6d0d8f4273c3f26d",
-        "url": "https://pkg.osquery.io/darwin/osquery-debug-2.10.2.pkg"
+        "platform": "darwin"
       },
       {
         "type": "RPM",
         "package": "osquery-debuginfo-2.10.0-1.linux.x86_64.rpm",
         "content": "c4ae75d842340d059d4c8ee7a76085b84394a2f796fb42cfa1b2b7ffb62a08be",
-        "url": "https://pkg.osquery.io/rpm/osquery-debuginfo-2.10.2-1.linux.x86_64.rpm"
+        "platform": "rpm"
       },
       {
         "type": "Debian",
         "package": "osquery-dbg_2.10.2_1.linux.amd64.deb",
         "content": "4217d086dec64e6544f6d9c613e6d39557d2f4cf343188b3ed47d926145ba7d4",
-        "url": "https://pkg.osquery.io/deb/osquery-dbg_2.10.2_1.linux.amd64.deb"
+        "platform": "deb"
       }
     ]
   }

--- a/src/data/osquery_package_versions/2.11.0.json
+++ b/src/data/osquery_package_versions/2.11.0.json
@@ -1,30 +1,31 @@
 {
   "version": "2.11.0",
+  "url": "https://pkg.osquery.io",
   "downloads": {
     "official": [
       {
         "type": "macOS",
         "package": "osquery-2.11.0.pkg",
         "content": "9e9249ffa5c0ac2e6d2212de6a24892ef37efabb039465b50d07ef01ba05fa14",
-        "url": "https://pkg.osquery.io/darwin/osquery-2.11.0.pkg"
+        "platform": "darwin"
       },
       {
         "type": "Linux",
         "package": "osquery-2.11.0_1.linux_x86_64.tar.gz",
         "content": "7df295e5cd56d957c199fcea1d243ee6e49f568005c534d7c610c661a3267d0f",
-        "url": "https://pkg.osquery.io/linux/osquery-2.11.0_1.linux_x86_64.tar.gz"
+        "platform": "linux"
       },
       {
         "type": "RPM",
         "package": "osquery-2.11.0-1.linux.x86_64.rpm",
         "content": "cf89311f647c35fc682d2af18ef9811cc2e4531243975fe866691bef42a77df4",
-        "url": "https://pkg.osquery.io/rpm/osquery-2.11.0-1.linux.x86_64.rpm"
+        "platform": "rpm"
       },
       {
         "type": "Debian",
         "package": "osquery_2.11.0_1.linux.amd64.deb",
         "content": "5a6e9ab30fdcd8fd6c2e43eb2a931ecca1c38684f7499914474ff73020bda083",
-        "url": "https://pkg.osquery.io/deb/osquery_2.11.0_1.linux.amd64.deb"
+        "platform": "deb"
       }
     ],
     "debug": [
@@ -32,19 +33,19 @@
         "type": "macOS",
         "package": "osquery-debug-2.11.0.pkg",
         "content": "e22747f01891e4d5e2cedc480766b6012a60bf3c5fb3c29bc7604e521e82fb81",
-        "url": "https://pkg.osquery.io/darwin/osquery-debug-2.11.0.pkg"
+        "platform": "darwin"
       },
       {
         "type": "RPM",
         "package": "osquery-debuginfo-2.11.0-1.linux.x86_64.rpm",
         "content": "fc372abb782ab1e242d2837a250978716ee2d04150e4cbd525029a6c0a0c7d63",
-        "url": "https://pkg.osquery.io/rpm/osquery-debuginfo-2.11.0-1.linux.x86_64.rpm"
+        "platform": "rpm"
       },
       {
         "type": "Debian",
         "package": "osquery-dbg_2.11.0_1.linux.amd64.deb",
         "content": "5a6e9ab30fdcd8fd6c2e43eb2a931ecca1c38684f7499914474ff73020bda083",
-        "url": "https://pkg.osquery.io/deb/osquery-dbg_2.11.0_1.linux.amd64.deb"
+        "platform": "deb"
       }
     ]
   }

--- a/src/data/osquery_package_versions/2.11.2.json
+++ b/src/data/osquery_package_versions/2.11.2.json
@@ -1,36 +1,37 @@
 {
   "version": "2.11.2",
+  "url": "https://pkg.osquery.io",
   "downloads": {
     "official": [
       {
         "type": "macOS",
         "package": "osquery-2.11.2.pkg",
         "content": "c28e561c9626e5fa2e7be06df73a63a96f1ca76c0e591ab492d3354745713476",
-        "url": "https://pkg.osquery.io/darwin/osquery-2.11.2.pkg"
+        "platform": "darwin"
       },
       {
         "type": "Linux",
         "package": "osquery-2.11.2_1.linux_x86_64.tar.gz",
         "content": "6b9f032bf04a0a938c4cd2a7f24f0f4fef1aca8593661f3801822760b178fdbd",
-        "url": "https://pkg.osquery.io/linux/osquery-2.11.2_1.linux_x86_64.tar.gz"
+        "platform": "linux"
       },
       {
         "type": "RPM",
         "package": "osquery-2.11.2-1.linux.x86_64.rpm",
         "content": "e7dd21d76b33b4ccad5280a8685f71a557bc008c2aaa41cfa696aa1d537bedad",
-        "url": "https://pkg.osquery.io/rpm/osquery-2.11.2-1.linux.x86_64.rpm"
+        "platform": "rpm"
       },
       {
         "type": "Debian",
         "package": "osquery_2.11.2_1.linux.amd64.deb",
         "content": "cf140838778e0c32344a6aeb3f45d2ae2cd44f2e7ec9acb19fc99ff883d52ef5",
-        "url": "https://pkg.osquery.io/deb/osquery_2.11.2_1.linux.amd64.deb"
+        "platform": "deb"
       },
       {
         "type": "Windows",
         "package": "osquery-2.11.2.msi",
         "content": "dc1ab769c5960de24824184da63edcdda90b9bceda41d1fc8717bbfa8ab1d4bd",
-        "url": "https://pkg.osquery.io/windows/osquery-2.11.2.msi"
+        "platform": "windows"
       }
     ],
     "debug": [
@@ -38,19 +39,19 @@
         "type": "macOS",
         "package": "osquery-debug-2.11.2.pkg",
         "content": "bb30981eabb5be24bc06a95aa91c2afb9cbca8deaf00d8d83810bfe8107cad6a",
-        "url": "https://pkg.osquery.io/darwin/osquery-debug-2.11.2.pkg"
+        "platform": "darwin"
       },
       {
         "type": "RPM",
         "package": "osquery-debuginfo-2.11.2-1.linux.x86_64.rpm",
         "content": "4183781d064c970d3990aaaf7c4a51831a361b3ce4ed90d12730965901e9f73e",
-        "url": "https://pkg.osquery.io/rpm/osquery-debuginfo-2.11.2-1.linux.x86_64.rpm"
+        "platform": "rpm"
       },
       {
         "type": "Debian",
         "package": "osquery-dbg_2.11.2_1.linux.amd64.deb",
         "content": "8dba185c4a42849ec379b7acec9f2b6db3ca7b61e1627d5647d41a3d9834bc5c",
-        "url": "https://pkg.osquery.io/deb/osquery-dbg_2.11.2_1.linux.amd64.deb"
+        "platform": "deb"
       }
     ]
   }

--- a/src/data/osquery_package_versions/2.7.0.json
+++ b/src/data/osquery_package_versions/2.7.0.json
@@ -1,30 +1,31 @@
 {
   "version": "2.7.0",
+  "url": "https://pkg.osquery.io",
   "downloads": {
     "official": [
       {
         "type": "macOS",
         "package": "osquery-2.7.0.pkg",
         "content": "e5eaf91b5582252f136476391cdd17985cc614536f964f38ddf7eb9cb69d0213",
-        "url": "https://pkg.osquery.io/darwin/osquery-2.7.0.pkg"
+        "platform": "darwin"
       },
       {
         "type": "Linux",
         "package": "osquery-2.7.0_1.linux_x86_64.tar.gz",
         "content": "fdc74b15161a7dacb74dcff7d25a433b838eac3738f5c80be2926d43eb52637a",
-        "url": "https://pkg.osquery.io/linux/osquery-2.7.0_1.linux_x86_64.tar.gz"
+        "platform": "linux"
       },
       {
         "type": "RPM",
         "package": "osquery-2.7.0-1.linux.x86_64.rpm",
         "content": "42e4fbbec36bf189624ab43405e7ae7ff2a0562b5ec10a82b53de5a699c857b5",
-        "url": "https://pkg.osquery.io/rpm/osquery-2.7.0-1.linux.x86_64.rpm"
+        "platform": "rpm"
       },
       {
         "type": "Debian",
         "package": "osquery_2.7.0_1.linux.amd64.deb",
         "content": "f0f0d2b66393486e99b18bc200495a127eab3de2df1c66e8eb46a0502a12ecd7",
-        "url": "https://pkg.osquery.io/deb/osquery_2.7.0_1.linux.amd64.deb"
+        "platform": "deb"
       }
     ],
     "debug": [
@@ -32,19 +33,19 @@
         "type": "macOS",
         "package": "osquery-debug-2.7.0.pkg",
         "content": "e68ab68ddf2a34842666b9bfb743c534aab23722a3c8e8c887ac670fd294b4e7",
-        "url": "https://pkg.osquery.io/darwin/osquery-debug-2.7.0.pkg"
+        "platform": "darwin"
       },
       {
         "type": "RPM",
         "package": "osquery-debuginfo-2.7.0-1.linux.x86_64.rpm",
         "content": "2f742a31b9d204ca9d99a44186bf318c241a45f85a18bcf088fed37ef7b6fcbb",
-        "url": "https://pkg.osquery.io/rpm/osquery-debuginfo-2.7.0-1.linux.x86_64.rpm"
+        "platform": "rpm"
       },
       {
         "type": "Debian",
         "package": "osquery-dbg_2.7.0_1.linux.amd64.deb",
         "content": "b90463b20ae13b6cba4c5a9b36d8ece3847a75a82448205254f5ff3bcec0c2ee",
-        "url": "https://pkg.osquery.io/deb/osquery-dbg_2.7.0_1.linux.amd64.deb"
+        "platform": "deb"
       }
     ]
   }

--- a/src/data/osquery_package_versions/2.8.0.json
+++ b/src/data/osquery_package_versions/2.8.0.json
@@ -1,30 +1,31 @@
 {
   "version": "2.8.0",
+  "url": "https://pkg.osquery.io",
   "downloads": {
     "official": [
       {
         "type": "macOS",
         "package": "osquery-2.8.0.pkg",
         "content": "642bd56809ea4079263fb8a9be3c9c7b53168c9676882ccd84b013f9c997cbe0",
-        "url": "https://pkg.osquery.io/darwin/osquery-2.8.0.pkg"
+        "platform": "darwin"
       },
       {
         "type": "Linux",
         "package": "osquery-2.8.0_1.linux_x86_64.tar.gz",
         "content": "ec84b5128769f09a5513bc1d136504ca2f805580b73d602e73d2a90b1a87c80a",
-        "url": "https://pkg.osquery.io/linux/osquery-2.8.0_1.linux_x86_64.tar.gz"
+        "platform": "linux"
       },
       {
         "type": "RPM",
         "package": "osquery-2.8.0-1.linux.x86_64.rpm",
         "content": "429b56f3a07890ac0d3dc92f36551caea55a2a86cee737dd0fbe55c297caf053",
-        "url": "https://pkg.osquery.io/rpm/osquery-2.8.0-1.linux.x86_64.rpm"
+        "platform": "rpm"
       },
       {
         "type": "Debian",
         "package": "osquery_2.8.0_1.linux.amd64.deb",
         "content": "33a6a2233918706fa23df06dd9ff2c03bb7fc07425b645e3d882f70babddb3a4",
-        "url": "https://pkg.osquery.io/deb/osquery_2.8.0_1.linux.amd64.deb"
+        "platform": "deb"
       }
     ],
     "debug": [
@@ -32,19 +33,19 @@
         "type": "macOS",
         "package": "osquery-debug-2.8.0.pkg",
         "content": "e62b45331977d1a15193a8c80c916c3aa281cc9ff403f7553f9f262394780b2e",
-        "url": "https://pkg.osquery.io/darwin/osquery-debug-2.8.0.pkg"
+        "platform": "darwin"
       },
       {
         "type": "RPM",
         "package": "osquery-debuginfo-2.8.0-1.linux.x86_64.rpm",
         "content": "f6dcbcb160cc431ddab0b4d8bf29ac16fde1f82eab843bf65696de9c9462b7ff",
-        "url": "https://pkg.osquery.io/rpm/osquery-debuginfo-2.8.0-1.linux.x86_64.rpm"
+        "platform": "rpm"
       },
       {
         "type": "Debian",
         "package": "osquery-dbg_2.8.0_1.linux.amd64.deb",
         "content": "e91386dab8d11525b28636e84300557f1e82d9bc33a390d751b60c03c01f08cc",
-        "url": "https://pkg.osquery.io/deb/osquery-dbg_2.8.0_1.linux.amd64.deb"
+        "platform": "deb"
       }
     ]
   }

--- a/src/data/osquery_package_versions/2.9.0.json
+++ b/src/data/osquery_package_versions/2.9.0.json
@@ -1,30 +1,31 @@
 {
   "version": "2.9.0",
+  "url": "https://pkg.osquery.io",
   "downloads": {
     "official": [
       {
         "type": "macOS",
         "package": "osquery-2.9.0.pkg",
         "content": "83541f1241a8b92eee9cfa3dd32f384a2fd1c7ca639f138e3ec716e7ec5177a3",
-        "url": "https://pkg.osquery.io/darwin/osquery-2.9.0.pkg"
+        "platform": "darwin"
       },
       {
         "type": "Linux",
         "package": "osquery-2.9.0_1.linux_x86_64.tar.gz",
         "content": "94684419037709386dcaa42e5b519e36370bb640d230f8d3852fb66fe1e23bb0",
-        "url": "https://pkg.osquery.io/linux/osquery-2.9.0_1.linux_x86_64.tar.gz"
+        "platform": "linux"
       },
       {
         "type": "RPM",
         "package": "osquery-2.9.0-1.linux.x86_64.rpm",
         "content": "411ec4e7d84ed65e3915993824e424e54aeb358e60596059b268b27f3720b5e3",
-        "url": "https://pkg.osquery.io/rpm/osquery-2.9.0-1.linux.x86_64.rpm"
+        "platform": "rpm"
       },
       {
         "type": "Debian",
         "package": "osquery_2.9.0_1.linux.amd64.deb",
         "content": "898cd16b1df9bc7aeef91542611b0e209ff7e8b0aae273fafbf5ef9f77ed0037",
-        "url": "https://pkg.osquery.io/deb/osquery_2.9.0_1.linux.amd64.deb"
+        "platform": "deb"
       }
     ],
     "debug": [
@@ -32,19 +33,19 @@
         "type": "macOS",
         "package": "osquery-debug-2.9.0.pkg",
         "content": "3485bbf23d1e11e1bb2406f61b0f087f18b8f1d69b32e41a3c20bb79a1621905",
-        "url": "https://pkg.osquery.io/darwin/osquery-debug-2.9.0.pkg"
+        "platform": "darwin"
       },
       {
         "type": "RPM",
         "package": "osquery-debuginfo-2.9.0-1.linux.x86_64.rpm",
         "content": "8ea330e12787f392b3989cb3cb4aaa4c0d2e6ccc60f361d5fa5b6499411d2af0",
-        "url": "https://pkg.osquery.io/rpm/osquery-debuginfo-2.9.0-1.linux.x86_64.rpm"
+        "platform": "rpm"
       },
       {
         "type": "Debian",
         "package": "osquery-dbg_2.9.0_1.linux.amd64.deb",
         "content": "a4b3c43362b1aff39607b942e81f10d50a0daa51bb32138c9969b1fb7a1c0fdb",
-        "url": "https://pkg.osquery.io/deb/osquery-dbg_2.9.0_1.linux.amd64.deb"
+        "platform": "deb"
       }
     ]
   }

--- a/src/data/osquery_package_versions/3.2.4.json
+++ b/src/data/osquery_package_versions/3.2.4.json
@@ -1,36 +1,37 @@
 {
   "version": "3.2.4",
+  "url": "https://pkg.osquery.io",
   "downloads": {
     "official": [
       {
         "type": "macOS",
         "package": "osquery-3.2.4.pkg",
         "content": "953ebeaec271bb1aaefa80df266a27f1364ea46d3db8dbd4c9f463204131a943",
-        "url": "https://pkg.osquery.io/darwin/osquery-3.2.4.pkg"
+        "platform": "darwin"
       },
       {
         "type": "Linux",
         "package": "osquery-3.2.4_1.linux_x86_64.tar.gz",
         "content": "9ae9c0b935288bb066571b1eebdf71095a1271e32871bb8eb71e4fda2183b8a7",
-        "url": "https://pkg.osquery.io/linux/osquery-3.2.4_1.linux_x86_64.tar.gz"
+        "platform": "linux"
       },
       {
         "type": "RPM",
         "package": "osquery-3.2.4-1.linux.x86_64.rpm",
         "content": "e1b8d8958b4e69631ca905b9e12da82e97f116b9f4e00d19f9faf65f423d1a57",
-        "url": "https://pkg.osquery.io/rpm/osquery-3.2.4-1.linux.x86_64.rpm"
+        "platform": "rpm"
       },
       {
         "type": "Debian",
         "package": "osquery_3.2.4_1.linux.amd64.deb",
         "content": "5c6bf38532f73c16ce1a7f33445bfa130979c30036b012426109d87472655bfd",
-        "url": "https://pkg.osquery.io/deb/osquery_3.2.4_1.linux.amd64.deb"
+        "platform": "deb"
       },
       {
         "type": "Windows",
         "package": "osquery-3.2.4.msi",
         "content": "14d57dcb55f74ce7944e9163ee1113d877691f03874c8220d23d4b86bfb58ff3",
-        "url": "https://pkg.osquery.io/windows/osquery-3.2.4.msi"
+        "platform": "windows"
       }
     ],
     "debug": [
@@ -38,19 +39,19 @@
         "type": "macOS",
         "package": "osquery-debug-3.2.4.pkg",
         "content": "3a72bb0d7a18387b672b345488168dd93c08a3dc21df825a5426c69ea4693f22",
-        "url": "https://pkg.osquery.io/darwin/osquery-debug-3.2.4.pkg"
+        "platform": "darwin"
       },
       {
         "type": "RPM",
         "package": "osquery-debuginfo-3.2.4-1.linux.x86_64.rpm",
         "content": "2c61af92c2e50a8621972e4550d151029cf8cdefb5f0347461060a681c6922b4",
-        "url": "https://pkg.osquery.io/rpm/osquery-debuginfo-3.2.4-1.linux.x86_64.rpm"
+        "platform": "rpm"
       },
       {
         "type": "Debian",
         "package": "osquery-dbg_2.10.2_1.linux.amd64.deb",
         "content": "185f851959ad2a8a09c1a4ae13a5f047c88e50926c4e8156d70a7d16be33a8c8",
-        "url": "https://pkg.osquery.io/deb/osquery-dbg_.linux.amd64.deb"
+        "platform": "deb"
       }
     ]
   }

--- a/src/data/osquery_package_versions/3.2.6.json
+++ b/src/data/osquery_package_versions/3.2.6.json
@@ -1,36 +1,37 @@
 {
   "version": "3.2.6",
+  "url": "https://pkg.osquery.io",
   "downloads": {
     "official": [
       {
         "type": "macOS",
         "package": "osquery-3.2.6.pkg",
         "content": "24975d47f36fe0dde27ce4273f99d13bfc664d1f1cff52752b6bca09f05be97b",
-        "url": "https://pkg.osquery.io/darwin/osquery-3.2.6.pkg"
+        "platform": "darwin"
       },
       {
         "type": "Linux",
-        "package": "osquery-.linux_x86_64.tar.gz",
+        "package": "osquery-3.2.6_1.linux_x86_64.tar.gz",
         "content": "cb9b1d47bbc8cd2e014914cd035b969278901a7745b2646a439bcad64d517a83",
-        "url": "https://pkg.osquery.io/linux/osquery-.linux_x86_64.tar.gz"
+        "platform": "linux"
       },
       {
         "type": "RPM",
         "package": "osquery-3.2.6-1.linux.x86_64.rpm",
         "content": "221596c3e9e9bf8ba99b54c335c923ac314dd4da72a9ca3c40a15f158a179bd9",
-        "url": "https://pkg.osquery.io/rpm/osquery-3.2.6-1.linux.x86_64.rpm"
+        "platform": "rpm"
       },
       {
         "type": "Debian",
-        "package": "osquery_.linux.amd64.deb",
+        "package": "osquery_3.2.6_1.linux.amd64.deb",
         "content": "b00d9104b08de734995b0a36fe6197d985b5ebb4e33c914dc23c2fba23d7f511",
-        "url": "https://pkg.osquery.io/deb/osquery_.linux.amd64.deb"
+        "platform": "deb"
       },
       {
         "type": "Windows",
         "package": "osquery-3.2.6.msi",
         "content": "0632a43c37e1c169ff313290b9460258d6bd6edc7764b446ec2de02e588905bf",
-        "url": "https://pkg.osquery.io/windows/osquery-3.2.6.msi"
+        "platform": "windows"
       }
     ],
     "debug": [
@@ -38,19 +39,19 @@
         "type": "macOS",
         "package": "osquery-debug-3.2.6.pkg",
         "content": "55c38004be5e1fec382c341377f83d0ce9dbeb93930e1eeecacf79b4081b4045",
-        "url": "https://pkg.osquery.io/darwin/osquery-debug-3.2.6.pkg"
+        "platform": "darwin"
       },
       {
         "type": "RPM",
         "package": "osquery-debuginfo-3.2.6-1.linux.x86_64.rpm",
         "content": "15d6f1ddec37b54647d6fcd88f30defb8cbaf8a30f71138dca6106953b40698a",
-        "url": "https://pkg.osquery.io/rpm/osquery-debuginfo-3.2.6-1.linux.x86_64.rpm"
+        "platform": "rpm"
       },
       {
         "type": "Debian",
         "package": "osquery-dbg_2.10.2_1.linux.amd64.deb",
         "content": "364c78bbabf42924cbf135b5832765c5268c75199700194733ab8c2edbab409e",
-        "url": "https://pkg.osquery.io/deb/osquery-dbg_.linux.amd64.deb"
+        "platform": "deb"
       }
     ]
   }

--- a/src/pages/Downloads/Downloads.js
+++ b/src/pages/Downloads/Downloads.js
@@ -69,8 +69,6 @@ class Downloads extends Component {
       osqueryVersion
     }`)
 
-    console.log('downloadsDataForOsqueryVersion', downloadsDataForOsqueryVersion)
-
     if (!schemaVersionExists(osqueryVersion) || ![DEBUG, OFFICIAL].includes(releaseType)) {
       return <NotFound />
     }

--- a/src/pages/Downloads/Downloads.js
+++ b/src/pages/Downloads/Downloads.js
@@ -69,6 +69,8 @@ class Downloads extends Component {
       osqueryVersion
     }`)
 
+    console.log('downloadsDataForOsqueryVersion', downloadsDataForOsqueryVersion)
+
     if (!schemaVersionExists(osqueryVersion) || ![DEBUG, OFFICIAL].includes(releaseType)) {
       return <NotFound />
     }
@@ -117,6 +119,7 @@ class Downloads extends Component {
             {downloadsDataForOsqueryVersion.downloads[releaseType].map((data, idx) => {
               return (
                 <DownloadCard
+                  urlBase={downloadsDataForOsqueryVersion.url}
                   className={`${baseClass}__download-card`}
                   downloadData={data}
                   key={`download-card-${idx}`}

--- a/stories/index.js
+++ b/stories/index.js
@@ -130,7 +130,10 @@ storiesOf('Card', module)
   ))
   .add('Download card', () => (
     <div style={{ width: '270px' }}>
-      <DownloadCard downloadData={osqueryVersionData.downloads[0]} />
+      <DownloadCard
+        downloadData={osqueryVersionData.downloads.official[0]}
+        urlBase={osqueryVersionData.url}
+      />
     </div>
   ))
   .add('Osquery Table', () => (


### PR DESCRIPTION
This PR resolves the issue of a bad download links on 3.2.6 and potentially other versions. 
It also removes the explicit download links in favor of an implicitly built link.
This will reduce the number of places that a human must copy and paste these versions and filenames and the URLS will then be built at render.

This does duplicate the resolution provided in #87 - sorry about that! 

Closes #86 
