### PR TITLE
Changed the default star count for featured products to `--`

### DIFF
--- a/src/data/featured_projects.json
+++ b/src/data/featured_projects.json
@@ -3,63 +3,63 @@
     "description": "StreamAlert is a serverless, realtime data analysis framework which empowers you to ingest, analyze, and alert on data from any environment, using datasources and alerting logic you define.",
     "owner": "airbnb",
     "repo": "streamalert",
-    "star_count": 983,
+    "star_count": "--",
     "url": "https://github.com/airbnb/streamalert"
   },
   {
     "description": "an osquery fleet manager",
     "owner": "mwielgoszewski",
     "repo": "doorman",
-    "star_count": 312,
+    "star_count": "--",
     "url": "https://github.com/mwielgoszewski/doorman"
   },
   {
     "description": "Zentral is a framework to gather, process, and monitor system events and link them to an inventory.",
     "owner": "zentralopensource",
     "repo": "zentral",
-    "star_count": 224,
+    "star_count": "--",
     "url": "https://github.com/zentralopensource/zentral"
   },
   {
     "description": "A flexible control server for osquery fleets",
     "owner":"kolide",
     "repo":"fleet",
-    "star_count": 124,
+    "star_count": "--",
     "url": "https://github.com/kolide/fleet"
   },
   {
     "description": "A repository for using osquery for incident detection and response",
     "owner": "palantir",
     "repo": "osquery-configuration",
-    "star_count": 89,
+    "star_count": "--",
     "url": "https://github.com/palantir/osquery-configuration"
   },
   {
     "description": "A TLS endpoint for serving osquery configuration",
     "owner": "heroku",
     "repo": "windmill",
-    "star_count": 76,
+    "star_count": "--",
     "url": "https://github.com/heroku/windmill"
   },
   {
     "description": "python bindings for osquery",
     "owner": "osquery",
     "repo": "osquery-python",
-    "star_count": 74,
+    "star_count": "--",
     "url": "https://github.com/osquery/osquery-python"
   },
   {
     "description": "A lightweight osquery execution environment",
     "owner": "kolide",
     "repo": "launcher",
-    "star_count": 57,
+    "star_count": "--",
     "url": "https://github.com/kolide/launcher"
   },
   {
     "description": "Go bindings for Osquery",
     "owner": "kolide",
     "repo": "osquery-go",
-    "star_count": 55,
+    "star_count": "--",
     "url": "https://github.com/kolide/osquery-go"
   }
 ]


### PR DESCRIPTION
Changed the static (irrelevant) count to `--`.  This should, in theory, never be seen because the request/response/render should be complete long before the user has the opportunity to scroll down the screen. In the event that the request fails, `--` will be visible next to the star. Not exactly informative but I'm open to other suggestions.