### PR TITLE
Changed how we import react-select styles to fix #96.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,8 +18,6 @@
 
     <link href="https://fonts.googleapis.com/css?family=Lato:400,700,900" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:600,900" rel="stylesheet">
-
-    <link rel="stylesheet" href="https://unpkg.com/react-select/dist/react-select.css">
     <title>Osquery</title>
   </head>
   <body>

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import registerServiceWorker from './registerServiceWorker'
+import 'react-select/dist/react-select.css'
+
 import './index.css'
 
 import Router from 'Router'


### PR DESCRIPTION
We now import the CSS resources locally, as opposed to via CDN. This resolves  https://github.com/osquery/osquery-site/issues/96

Before:
<img width="691" alt="osquery schema 2018-07-24 13-24-25" src="https://user-images.githubusercontent.com/4217759/43155798-69992cca-8f46-11e8-9615-54bd73123aaf.png">

After:
<img width="652" alt="osquery schema 2018-07-24 13-32-11" src="https://user-images.githubusercontent.com/4217759/43155787-5d9ea44a-8f46-11e8-9e8c-5e3aa8a77075.png">