### PR TITLE
Remove extraneous space in event dates

### DIFF
--- a/src/components/EventListing/EventListing.js
+++ b/src/components/EventListing/EventListing.js
@@ -29,7 +29,6 @@ const EventListing = props => {
 
         <span className={`${baseClass}__date`}>
           <MediaQuery minWidth={mobileWidth + 1}>
-            {' '}
             , {endDate ? endDate.format('YYYY') : startDate.format('YYYY')}
           </MediaQuery>
         </span>


### PR DESCRIPTION
Removes the space before the comma in the year of the event.

Before:
<img width="549" alt="screen shot 2018-09-13 at 10 16 43 am" src="https://user-images.githubusercontent.com/575602/45504281-43506e00-b73e-11e8-9625-2f682691c54d.png">
After:
<img width="539" alt="screen shot 2018-09-13 at 10 17 18 am" src="https://user-images.githubusercontent.com/575602/45504290-477c8b80-b73e-11e8-8908-4d1ae3be5ba6.png">
