### PR TITLE
Adding online workshop

### DIFF
--- a/src/data/community_events/manifest.js
+++ b/src/data/community_events/manifest.js
@@ -1,3 +1,3 @@
 // Add your event's filename to this list
 
-export default ['querycon18', 'kolide-osquery-workshop']
+export default ['querycon18', 'kolide-osquery-workshop', 'uptycs-osquery-intro']

--- a/src/data/community_events/uptycs-osquery-intro.json
+++ b/src/data/community_events/uptycs-osquery-intro.json
@@ -1,0 +1,11 @@
+{
+  "title": "Uptycs Free Training: Intro to osquery",
+  "location": "online",
+  "url": "https://www.uptycs.com/free-osquery-training-intro-to-osquery",
+  "startYear": 2018,
+  "startMonth": 10,
+  "startDay": 10,
+  "endYear": 2018,
+  "endMonth": 12,
+  "endDay": 31
+}


### PR DESCRIPTION
We've created an online version of the "Intro to osquery" workshop that I have done at several conferences this year. Wanted to add it to the community "events" even though it is not at a fixed location, it's basically the same thing as the workshop I do in person.

Let me know if there is a better place to put it, but I figured this would be a good place for folks looking for community resources to find it.