### PR TITLE
Fix 404 on gh-pages when using non-homepage URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "start-js": "node scripts/start.js",
     "start": "npm-run-all -p watch-css start-js",
     "build-js": "node scripts/build.js",
-    "build": "npm-run-all build-css build-js",
+    "build": "npm-run-all build-css build-js && cp build/index.html build/404.html",
     "watch-css": "npm run build-css && node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/ --watch --recursive",
     "build-css": "node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/",
     "predeploy": "yarn run build",


### PR DESCRIPTION
Copy the index page to the 404 page so that the JS can attempt to load the URL.

Closes #138