### PR TITLE
Remove axios dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "**/sshpk": "1.16.1"
   },
   "dependencies": {
-    "axios": "^0.19.0",
     "chalk": "1.1.3",
     "classnames": "^2.2.5",
     "dotenv": "4.0.0",
@@ -61,7 +60,6 @@
     "@storybook/addon-actions": "^5.1.9",
     "@storybook/react": "^5.1.9",
     "autoprefixer": "7.1.6",
-    "axios": "^0.19.0",
     "babel-eslint": "^10.0.2",
     "babel-jest": "20.0.3",
     "babel-loader": "^8.0.6",

--- a/src/helpers/get_github_repo.js
+++ b/src/helpers/get_github_repo.js
@@ -1,10 +1,7 @@
-import axios from 'axios'
-
 const getGithubRepo = (owner, repo) => {
-  return axios({
-    method: 'get',
-    url: `https://api.github.com/repos/${owner}/${repo}`,
-  })
+  return fetch(`https://api.github.com/repos/${owner}/${repo}`, { method: 'get' }).then(response =>
+    response.json()
+  )
 }
 
 export default getGithubRepo

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -46,7 +46,7 @@ class Home extends Component {
 
   addFeaturedProject = (owner, repo) => {
     return getGithubRepo(owner, repo).then(response => {
-      const { description, name, owner, stargazers_count, html_url } = response.data
+      const { description, name, owner, stargazers_count, html_url } = response
 
       return Promise.resolve({
         description: description,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2303,14 +2303,6 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axios@^0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
-  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
-  dependencies:
-    follow-redirects "1.5.10"
-    is-buffer "^2.0.2"
-
 babel-code-frame@^6.11.0, babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -4116,13 +4108,6 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
-debug@=3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
-
 debug@^3.1.0, debug@^3.2.5, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
@@ -5253,13 +5238,6 @@ focus-lock@^0.6.3:
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.6.5.tgz#f6eb37832a9b1b205406175f5277396a28c0fce1"
   integrity sha512-i/mVBOoa9o+tl+u9owOJUF8k8L85odZNIsctB+JAK2HFT8jckiBwmk+3uydlm6FN8czgnkIwQtBv6yyAbrzXjw==
 
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
-
 follow-redirects@^1.0.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"
@@ -6334,7 +6312,7 @@ is-buffer@^1.0.2, is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-buffer@^2.0.0, is-buffer@^2.0.2:
+is-buffer@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
   integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==


### PR DESCRIPTION
Removes this large dependency that was only used in a single place. The
browser-native APIs provide a suitable replacement. This significantly
reduces the size of the compiled bundle, but has no significant change
after minimization and gzipping.