### PR TITLE
Fix download links

### DIFF
--- a/src/data/osquery_package_versions/4.0.1.json
+++ b/src/data/osquery_package_versions/4.0.1.json
@@ -1,36 +1,37 @@
 {
   "version": "4.0.1",
+  "url": "https://pkg.osquery.io",
   "downloads": {
     "official": [
       {
         "type": "macOS",
         "package": "osquery-4.0.1.pkg",
         "content": "bb906c96257ad18e81e69b4207e9410fab941ac3a388e52addfe56601f9a01d2",
-        "url": "https://pkg.osquery.io/darwin/osquery-4.0.1.pkg"
+        "platform": "darwin"
       },
       {
         "type": "Linux",
         "package": "osquery-4.0.1_1.linux_x86_64.tar.gz",
         "content": "5c72638b8c13f76142088d7ecd28531805a4696af1f54f2fb53a869f2fb8d15b",
-        "url": "https://pkg.osquery.io/linux/osquery-4.0.1_1.linux_x86_64.tar.gz"
+        "platform": "linux"
       },
       {
         "type": "RPM",
         "package": "osquery-4.0.1-1.linux.x86_64.rpm",
         "content": "676bd22b011bbf0dd8fd0ae974d9ffe7edfcdc9ae7b20f87341fd2d401f81d91",
-        "url": "https://pkg.osquery.io/rpm/osquery-4.0.1-1.linux.x86_64.rpm"
+        "platform": "rpm"
       },
       {
         "type": "Debian",
         "package": "osquery_4.0.1_1.linux.amd64.deb",
         "content": "7a28719a9c958fd0eb9123a4bee9e34b3c445b22841e498cc5da665da57dffda",
-        "url": "https://pkg.osquery.io/deb/osquery_4.0.1_1.linux.amd64.deb"
+        "platform": "deb"
       },
       {
         "type": "Windows",
         "package": "osquery-4.0.1.msi",
         "content": "8337739a2d405b4423db9dac867afdd94ed0c128833c0ee0f490f09a944b4f12",
-        "url": "https://pkg.osquery.io/windows/osquery-4.0.1.msi"
+        "platform": "windows"
       }
     ],
     "debug": [
@@ -38,19 +39,19 @@
         "type": "macOS",
         "package": "osquery-debug-4.0.1.pkg",
         "content": "223a5bac17e3545e7d45d52ea3fe0998e039a2775d7334a27f14e8080e83f479",
-        "url": "https://pkg.osquery.io/darwin/osquery-debug-4.0.1.pkg"
+        "platform": "darwin"
       },
       {
         "type": "RPM",
         "package": "osquery-debuginfo-4.0.1-1.linux.x86_64.rpm",
         "content": "329eae38dbb7e39cd17735e9d00f1a29bc5d766f55b339469bfd740b816eb052",
-        "url": "https://pkg.osquery.io/rpm/osquery-debuginfo-4.0.1-1.linux.x86_64.rpm"
+        "platform": "rpm"
       },
       {
         "type": "Debian",
         "package": "osquery-dbg_4.0.1_1.linux.amd64.deb",
         "content": "9f51b289957eee5d0ddef543138dbbe97953c8fc22daa62f94f916107b3cdb41",
-        "url": "https://pkg.osquery.io/deb/osquery-dbg_4.0.1_1.linux.amd64.deb"
+        "platform": "deb"
       }
     ]
   }


### PR DESCRIPTION
Looks like the generator script is out of date. Manually fix the links

This will need to be fixed in the new_release script as well.

Thanks @terracatta