### PR TITLE
Schema page: block scroll on sidebar hover without hiding

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -7,7 +7,9 @@ body {
   padding: 0;
 
   &.noscroll {
-    overflow: hidden;
+    position: fixed;
+    overflow-y: scroll;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
In the schema page we block the scroll of the main area
when we hover on the table list sidebar by hiding the scrollbars
with "overflow: hidden".
This though causes an update to the layout and everything moves
to the right when hovering the sidebar and to the left when not.

Instead of causing a layout change, we keep the scrollbars visible,
but we "disable" scrolling via "position: fixed".