### PR TITLE
blog: Add aarch64 beta post

### DIFF
--- a/src/data/blog/posts/official_news/2020-09-10-linux-arm64-beta-support.md
+++ b/src/data/blog/posts/official_news/2020-09-10-linux-arm64-beta-support.md
@@ -1,0 +1,26 @@
+---
+title:  "Linux ARM64 Beta Support"
+author: "Alessandro Gario"
+date: "2020-09-20 17:00"
+---
+
+We would like to announce beta support for Linux arm64/aarch64. And we are working diligently towards official releases and support for more operating systems. If you would like to test, please find beta packages for the 4.5.0 tag here:
+
+
+| Type    |    Filename / sha256  |
+|:------|:-------|
+| Tarball        | [osquery-4.5.0\_1.linux\_aarch64.tar.gz](https://pkg.osquery.io/osquery-4.5.0_1.linux_aarch64.tar) `19880dac2dc1ea7d1a5fbc5f91c3a8c55b26e64cfe402306bc78032c7b97f721` |
+| Debian         | [osquery\_4.5.0-1.linux\_arm64.deb](https://pkg.osquery.io/osquery_4.5.0-1.linux_arm64.deb) `f5d58f03200c26eadc2bf1e783fe56e264301ac892c8828cea16dadca475ad7b` |
+| Debian&nbsp;(Debug) | [osquery-dbgsym_4.5.0-1.linux\_arm64.ddeb](https://pkg.osquery.io/osquery-dbgsym_4.5.0-1.linux_arm64.ddeb) `f48db8c4182213cc61707de4d9dcaa90005a996710e52de7b5cba20c0cbfabf9` |
+| RPM            | [osquery-4.5.0-1.aarch64.rpm](https://pkg.osquery.io/osquery-4.5.0-1.aarch64.rpm) `fa4d17a5cdb3ec67989b3f275996fea92bec9ca62a01e6f5679863782d5d2dda` |
+| RPM&nbsp;(Debug)    | [osquery-debuginfo-4.5.0-1.aarch64.rpm](https://pkg.osquery.io/osquery-debuginfo-4.5.0-1.aarch64.rpm) `67608cfc6fed0479e8e47b9562235397fc7a459f471ee6f02adc3a0592aa6ce6` |
+
+
+
+They should follow the same portability expectations as x86, and work on any Linux distribution released since 2011.
+
+Bugs and incompatibilities should be filled as GitHub [issues](https://github.com/osquery/osquery/issues) on the osquery repository. Questions, comments, and discussions are taking place in the Slack channel `#arm-architecture` ([request an invite!](https://join.slack.com/t/osquery/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw))
+
+And of course if you would like to build osquery for aarch64 yourself, please follow our [building](https://osquery.readthedocs.io/en/latest/development/building/) guide. But use the [aarch64](https://github.com/osquery/osquery-toolchain/releases/download/1.1.0/osquery-toolchain-1.1.0-aarch64.tar.xz) version of our toolchain.
+
+A big thanks to everyone who made this possible, and specifically [artemist](https://github.com/artemist), [alessandrogario](https://github.com/alessandrogario), and [ozbenh](https://github.com/ozbenh).

--- a/src/data/blog/posts/official_news/2020-09-10-linux-arm64-beta-support.md
+++ b/src/data/blog/posts/official_news/2020-09-10-linux-arm64-beta-support.md
@@ -23,4 +23,4 @@ Bugs and incompatibilities should be filled as GitHub [issues](https://github.co
 
 And of course if you would like to build osquery for aarch64 yourself, please follow our [building](https://osquery.readthedocs.io/en/latest/development/building/) guide. But use the [aarch64](https://github.com/osquery/osquery-toolchain/releases/download/1.1.0/osquery-toolchain-1.1.0-aarch64.tar.xz) version of our toolchain.
 
-A big thanks to everyone who made this possible, and specifically [artemist](https://github.com/artemist), [alessandrogario](https://github.com/alessandrogario), and [ozbenh](https://github.com/ozbenh).
+A big thanks to everyone who made this possible, and specifically [artemist](https://github.com/artemist), [lizthegrey](https://github.com/lizthegrey), and [ozbenh](https://github.com/ozbenh).

--- a/src/data/blog/posts/official_news/2020-09-10-linux-arm64-beta-support.md
+++ b/src/data/blog/posts/official_news/2020-09-10-linux-arm64-beta-support.md
@@ -9,11 +9,11 @@ We would like to announce beta support for Linux arm64/aarch64. And we are worki
 
 | Type    |    Filename / sha256  |
 |:------|:-------|
-| Tarball        | [osquery-4.5.0\_1.linux\_aarch64.tar.gz](https://pkg.osquery.io/osquery-4.5.0_1.linux_aarch64.tar) `19880dac2dc1ea7d1a5fbc5f91c3a8c55b26e64cfe402306bc78032c7b97f721` |
-| Debian         | [osquery\_4.5.0-1.linux\_arm64.deb](https://pkg.osquery.io/osquery_4.5.0-1.linux_arm64.deb) `f5d58f03200c26eadc2bf1e783fe56e264301ac892c8828cea16dadca475ad7b` |
-| Debian&nbsp;(Debug) | [osquery-dbgsym_4.5.0-1.linux\_arm64.ddeb](https://pkg.osquery.io/osquery-dbgsym_4.5.0-1.linux_arm64.ddeb) `f48db8c4182213cc61707de4d9dcaa90005a996710e52de7b5cba20c0cbfabf9` |
-| RPM            | [osquery-4.5.0-1.aarch64.rpm](https://pkg.osquery.io/osquery-4.5.0-1.aarch64.rpm) `fa4d17a5cdb3ec67989b3f275996fea92bec9ca62a01e6f5679863782d5d2dda` |
-| RPM&nbsp;(Debug)    | [osquery-debuginfo-4.5.0-1.aarch64.rpm](https://pkg.osquery.io/osquery-debuginfo-4.5.0-1.aarch64.rpm) `67608cfc6fed0479e8e47b9562235397fc7a459f471ee6f02adc3a0592aa6ce6` |
+| Tarball        | [osquery-4.5.0\_1.linux\_aarch64.tar.gz](https://pkg.osquery.io/linux/osquery-4.5.0_1.linux_aarch64.tar) `b26929aceb2cc84511ba7d02bb22a092eb17047c54487df60c487ac880f79c02` |
+| Debian         | [osquery\_4.5.0\_1.linux.arm64.deb](https://pkg.osquery.io/deb/osquery_4.5.0_1.linux.arm64.deb) `5502cc70fa38ea7e8a6bc243ec16ca90ac1443fc9fd7c15ec9cfd28aa35f0900` |
+| Debian&nbsp;(Debug) | [osquery-dbgsym_4.5.0\_1.linux.arm64.ddeb](https://pkg.osquery.io/deb/osquery-dbgsym_4.5.0_1.linux.arm64.deb) `4e63a8605519fc51095e7ef70f3f9ae93adcb7aef29ca1a398caf2f3f77b73fb` |
+| RPM            | [osquery-4.5.0-1.linux.aarch64.rpm](https://pkg.osquery.io/rpm/osquery-4.5.0-1.linux.aarch64.rpm) `1d482d9151d58d58af519470595f2968c75b389426e6b8f80a742058966c1b05` |
+| RPM&nbsp;(Debug)    | [osquery-debuginfo-4.5.0-1.linux.aarch64.rpm](https://pkg.osquery.io/rpm/osquery-debuginfo-4.5.0-1.linux.aarch64.rpm) `a9af73b2e465ceaa6b2954ec401d458443dc8d0d0dc003c65f5d84f620a5c609` |
 
 
 

--- a/src/data/blog/posts/official_news/2020-09-10-linux-arm64-beta-support.md
+++ b/src/data/blog/posts/official_news/2020-09-10-linux-arm64-beta-support.md
@@ -9,7 +9,7 @@ We would like to announce beta support for Linux arm64/aarch64. And we are worki
 
 | Type    |    Filename / sha256  |
 |:------|:-------|
-| Tarball        | [osquery-4.5.0\_1.linux\_aarch64.tar.gz](https://pkg.osquery.io/linux/osquery-4.5.0_1.linux_aarch64.tar) `b26929aceb2cc84511ba7d02bb22a092eb17047c54487df60c487ac880f79c02` |
+| Tarball        | [osquery-4.5.0\_1.linux\_aarch64.tar.gz](https://pkg.osquery.io/linux/osquery-4.5.0_1.linux_aarch64.tar.gz) `b26929aceb2cc84511ba7d02bb22a092eb17047c54487df60c487ac880f79c02` |
 | Debian         | [osquery\_4.5.0\_1.linux.arm64.deb](https://pkg.osquery.io/deb/osquery_4.5.0_1.linux.arm64.deb) `5502cc70fa38ea7e8a6bc243ec16ca90ac1443fc9fd7c15ec9cfd28aa35f0900` |
 | Debian&nbsp;(Debug) | [osquery-dbgsym_4.5.0\_1.linux.arm64.ddeb](https://pkg.osquery.io/deb/osquery-dbgsym_4.5.0_1.linux.arm64.deb) `4e63a8605519fc51095e7ef70f3f9ae93adcb7aef29ca1a398caf2f3f77b73fb` |
 | RPM            | [osquery-4.5.0-1.linux.aarch64.rpm](https://pkg.osquery.io/rpm/osquery-4.5.0-1.linux.aarch64.rpm) `1d482d9151d58d58af519470595f2968c75b389426e6b8f80a742058966c1b05` |

--- a/src/data/blog/posts/official_news/2020-09-10-linux-arm64-beta-support.md
+++ b/src/data/blog/posts/official_news/2020-09-10-linux-arm64-beta-support.md
@@ -1,17 +1,17 @@
 ---
 title:  "Linux ARM64 Beta Support"
 author: "Alessandro Gario"
-date: "2020-09-20 17:00"
+date: "2020-09-18 21:00"
 ---
 
-We would like to announce beta support for Linux arm64/aarch64. And we are working diligently towards official releases and support for more operating systems. If you would like to test, please find beta packages for the 4.5.0 tag here:
+We would like to announce beta support for Linux arm64/aarch64. We are working diligently towards official releases and support for more operating systems. If you would like to test, please find beta packages for the 4.5.0 tag here:
 
 
 | Type    |    Filename / sha256  |
 |:------|:-------|
 | Tarball        | [osquery-4.5.0\_1.linux\_aarch64.tar.gz](https://pkg.osquery.io/linux/osquery-4.5.0_1.linux_aarch64.tar.gz) `b26929aceb2cc84511ba7d02bb22a092eb17047c54487df60c487ac880f79c02` |
 | Debian         | [osquery\_4.5.0\_1.linux.arm64.deb](https://pkg.osquery.io/deb/osquery_4.5.0_1.linux.arm64.deb) `5502cc70fa38ea7e8a6bc243ec16ca90ac1443fc9fd7c15ec9cfd28aa35f0900` |
-| Debian&nbsp;(Debug) | [osquery-dbgsym_4.5.0\_1.linux.arm64.ddeb](https://pkg.osquery.io/deb/osquery-dbgsym_4.5.0_1.linux.arm64.deb) `4e63a8605519fc51095e7ef70f3f9ae93adcb7aef29ca1a398caf2f3f77b73fb` |
+| Debian&nbsp;(Debug) | [osquery-dbgsym_4.5.0\_1.linux.arm64.deb](https://pkg.osquery.io/deb/osquery-dbgsym_4.5.0_1.linux.arm64.deb) `4e63a8605519fc51095e7ef70f3f9ae93adcb7aef29ca1a398caf2f3f77b73fb` |
 | RPM            | [osquery-4.5.0-1.linux.aarch64.rpm](https://pkg.osquery.io/rpm/osquery-4.5.0-1.linux.aarch64.rpm) `1d482d9151d58d58af519470595f2968c75b389426e6b8f80a742058966c1b05` |
 | RPM&nbsp;(Debug)    | [osquery-debuginfo-4.5.0-1.linux.aarch64.rpm](https://pkg.osquery.io/rpm/osquery-debuginfo-4.5.0-1.linux.aarch64.rpm) `a9af73b2e465ceaa6b2954ec401d458443dc8d0d0dc003c65f5d84f620a5c609` |
 
@@ -21,6 +21,6 @@ They should follow the same portability expectations as x86, and work on any Lin
 
 Bugs and incompatibilities should be filled as GitHub [issues](https://github.com/osquery/osquery/issues) on the osquery repository. Questions, comments, and discussions are taking place in the Slack channel `#arm-architecture` ([request an invite!](https://join.slack.com/t/osquery/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw))
 
-And of course if you would like to build osquery for aarch64 yourself, please follow our [building](https://osquery.readthedocs.io/en/latest/development/building/) guide. But use the [aarch64](https://github.com/osquery/osquery-toolchain/releases/download/1.1.0/osquery-toolchain-1.1.0-aarch64.tar.xz) version of our toolchain.
+And of course, if you would like to build osquery for aarch64 yourself, please follow our [building](https://osquery.readthedocs.io/en/latest/development/building/) guide. But use the [aarch64](https://github.com/osquery/osquery-toolchain/releases/download/1.1.0/osquery-toolchain-1.1.0-aarch64.tar.xz) version of our toolchain.
 
 A big thanks to everyone who made this possible, and specifically [artemist](https://github.com/artemist), [lizthegrey](https://github.com/lizthegrey), and [ozbenh](https://github.com/ozbenh).

--- a/src/pages/BlogShow/BlogShow.js
+++ b/src/pages/BlogShow/BlogShow.js
@@ -15,7 +15,7 @@ class BlogShow extends Component {
   constructor(props) {
     super(props)
 
-    this.converter = new showdown.Converter()
+    this.converter = new showdown.Converter({ tables: true })
 
     this.state = {
       blogPost: undefined,

--- a/src/pages/BlogShow/BlogShow.scss
+++ b/src/pages/BlogShow/BlogShow.scss
@@ -3,3 +3,41 @@
   display: flex;
   flex-direction: column;
 }
+
+table {
+  padding: 0;
+  border-collapse:collapse;
+}
+table tr {
+  border-top: 1px solid #cccccc;
+  background-color: white;
+  margin: 0;
+  padding: 0;
+}
+
+table tr:nth-child(2n) {
+  background-color: #f8f8f8;
+}
+
+table tr th {
+  font-weight: bold;
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 6px 13px;
+}
+
+table tr td {
+  border: 1px solid #cccccc;
+  text-align: left;
+  margin: 0;
+  padding: 6px 13px;
+}
+
+table tr th :first-child, table tr td :first-child {
+  margin-top: 0;
+}
+
+table tr th :last-child, table tr td :last-child {
+  margin-bottom: 0;
+}

--- a/src/pages/Downloads/Downloads.js
+++ b/src/pages/Downloads/Downloads.js
@@ -19,6 +19,7 @@ import './Downloads.css'
 
 const DEBUG = 'debug'
 const OFFICIAL = 'official'
+const AARCH64 = 'aarch64'
 
 const baseClass = 'downloads-page'
 const installOptionNames = {
@@ -62,9 +63,22 @@ class Downloads extends Component {
     }
   }
 
+  onGoToAarch64Blog = () => {
+    return () => {
+      const { history, match } = this.props
+
+      history.push(`${process.env.PUBLIC_URL}/blog/linux-arm64-beta-support`)
+    }
+  }
+
   render() {
     const { match } = this.props
-    const { onInstallOptionChange, onOsqueryVersionChange, onReleaseTypeChange } = this
+    const {
+      onInstallOptionChange,
+      onOsqueryVersionChange,
+      onReleaseTypeChange,
+      onGoToAarch64Blog,
+    } = this
     const { osquery_version: osqueryVersion, release_type: releaseType } = match.params
     const { selectedInstallOption } = this.state
     const alternativeInstallOptionContent =
@@ -111,6 +125,13 @@ class Downloads extends Component {
             className={`${baseClass}__tab`}
             onClick={onReleaseTypeChange(DEBUG)}
             text="Debug"
+          />
+
+          <Tab
+            active={releaseType === AARCH64}
+            className={`${baseClass}__tab ${baseClass}__tab--arm64`}
+            onClick={onGoToAarch64Blog()}
+            text="ARM64"
           />
 
           <div className={`section-break ${baseClass}__section-break`} />

--- a/src/pages/Downloads/Downloads.scss
+++ b/src/pages/Downloads/Downloads.scss
@@ -49,6 +49,10 @@
   margin-right: 24px;
 }
 
+.downloads-page__tab--arm64 {
+  margin-left: 24px;
+}
+
 .downloads-page__pill-wrapper {
   margin-top: 32px;
 }


### PR DESCRIPTION
Heads up that the download locations and hashes are placeholders. When there is a real 4.5.0 tag and when real packages are built I will upload and update the data here.

@alessandrogario please review and let me know if you have suggestions.