### PR TITLE
Updating "Upcoming Community Events" with osquery@scale 2021

### DIFF
--- a/src/data/community_events/manifest.js
+++ b/src/data/community_events/manifest.js
@@ -11,4 +11,5 @@ export default [
   'hackmiami19',
   'osquery@scale',
   'bsidesslc20',
+  'osquery@scale2021',
 ]

--- a/src/data/community_events/osquery@scale2021.json
+++ b/src/data/community_events/osquery@scale2021.json
@@ -1,0 +1,8 @@
+{
+  "title": "osquery@scale: explore from home",
+  "location": "Virtual",
+  "url": "https://www.osqueryatscale.com/",
+  "startYear": 2021,
+  "startMonth": 1,
+  "startDay": 20
+}


### PR DESCRIPTION
Historically this medium has been understandably reserved for live events. Given the climate of live events, I thought it would be appropriate to make this request. 