### PR TITLE
Update `brew install` instructions

### DIFF
--- a/src/data/pages/downloads.json
+++ b/src/data/pages/downloads.json
@@ -14,8 +14,7 @@
           "subSection1Heading": "Install darwin repository",
           "subSection1Paragraph1": "osquery can be installed from the Homebrew Cask repository.",
           "terminalCommands": [
-            "brew update",
-            "brew cask install osquery"
+            "brew install --cask osquery"
           ]
         },
         "ubuntu": {


### PR DESCRIPTION
Update `brew install` instructions to:

1. Remove `brew update` (it's auto-updating so not required)
2. Change `brew cask install osquery` to `brew install --cask osquery` as per the new method.