### PR TITLE
Fix YUM repo install instructions

### DIFF
--- a/src/data/pages/downloads.json
+++ b/src/data/pages/downloads.json
@@ -34,7 +34,7 @@
           "terminalCommands": [
             "curl -L https://pkg.osquery.io/rpm/GPG | sudo tee /etc/pki/rpm-gpg/RPM-GPG-KEY-osquery",
             "sudo yum-config-manager --add-repo https://pkg.osquery.io/rpm/osquery-s3-rpm.repo",
-            "sudo yum-config-manager --enable osquery-s3-rpm",
+            "sudo yum-config-manager --enable osquery-s3-rpm-repo",
             "sudo yum install osquery"
           ]
         },


### PR DESCRIPTION
It looks like the file https://pkg.osquery.io/rpm/osquery-s3-rpm.repo names the repo `osquery-s3-rpm-repo`.