### PR TITLE
Update Windows 4.9.0 hash after GH workflow was rerun

### DIFF
--- a/src/data/osquery_package_versions/4.9.0.json
+++ b/src/data/osquery_package_versions/4.9.0.json
@@ -13,7 +13,7 @@
         "type": "Windows",
         "package": "osquery-4.9.0.msi",
         "platform": "windows",
-        "content": "fa6ff1be31cbe935a27efe67114900cec26d79513a3e51d1618bd693f91ae84e"
+        "content": "ae5e8b5948f3e2783aadc66e8b9d5d417b8606b39abf79f06af466c3455ce249"
       },
       {
         "type": "Linux (x86_64)",


### PR DESCRIPTION
Heads up @directionless and @muffins, we need to coordinate re-running GH workflows after a release. When the S3 and tag assets are updated, the hash on the website needs to be updated too. It's best to only run those workflows once.