### PR TITLE
Make terminal prompt unselectable in install commands

### DIFF
--- a/src/pages/Downloads/Downloads.js
+++ b/src/pages/Downloads/Downloads.js
@@ -164,7 +164,12 @@ class Downloads extends Component {
           <Terminal.Wrapper className={`${baseClass}__terminal`}>
             <Terminal.Body className={`${baseClass}__terminal-body`}>
               {alternativeInstallOptionContent.terminalCommands.map((terminalCommand, idx) => {
-                return <Monospace key={`terminal-command-${idx}`}>$ {terminalCommand}</Monospace>
+                return (
+                  <Monospace key={`terminal-command-${idx}`}>
+                    <label className="unselectable">$</label> {terminalCommand}
+                    <br />
+                  </Monospace>
+                )
               })}
             </Terminal.Body>
           </Terminal.Wrapper>

--- a/src/pages/Downloads/Downloads.scss
+++ b/src/pages/Downloads/Downloads.scss
@@ -109,6 +109,15 @@
     font-size: 14px;
     font-weight: 600;
   }
+
+  .unselectable {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
 }
 
 .downloads-page__packages-section {


### PR DESCRIPTION
This makes copy/pasting the terminal commands much better. The whole
block can be copied at once without syntax errors that previously
occurred due to copying the `$` characters.

Tested on macOS Chrome and Firefox.