### PR TITLE
Fix schema page visual jumping #49

### DIFF
--- a/src/components/SchemaTOC/SchemaTOC.js
+++ b/src/components/SchemaTOC/SchemaTOC.js
@@ -23,19 +23,6 @@ class SchemaTOC extends Component {
     return () => onEntryClick(tableName)
   }
 
-  preventBodyScroll = () => document.body.classList.add('noscroll')
-  allowBodyScroll = () => document.body.classList.remove('noscroll')
-
-  componentDidMount() {
-    this.toc.addEventListener('mouseenter', this.preventBodyScroll)
-    this.toc.addEventListener('mouseleave', this.allowBodyScroll)
-  }
-
-  componentWillUnmount() {
-    this.toc.removeEventListener('mouseenter', this.preventBodyScroll)
-    this.toc.removeEventListener('mouseleave', this.allowBodyScroll)
-  }
-
   render() {
     const { handleClick } = this
     const { activeEntry, tables } = this.props

--- a/src/components/SchemaTOC/SchemaTOC.scss
+++ b/src/components/SchemaTOC/SchemaTOC.scss
@@ -3,4 +3,5 @@
 .schema-toc {
   max-height: 70vh;
   overflow: auto;
+  overscroll-behavior: none;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -5,10 +5,6 @@ body {
   margin: 0;
   min-height: 100vh;
   padding: 0;
-
-  &.noscroll {
-    overflow: hidden;
-  }
 }
 
 #root {


### PR DESCRIPTION
toggle 'noscroll' style on body will cause #49 issue in some browsers

this pr instead use `overscroll-behavior: none` to prevent over scrolling on side list that causing scrolling chain