### PR TITLE
Update the downloads page to include more alternates

### DIFF
--- a/src/data/pages/downloads.json
+++ b/src/data/pages/downloads.json
@@ -11,37 +11,58 @@
       "sectionHeading": "Alternative Installation Options",
       "subheadings": {
         "darwin": {
-          "subSection1Heading": "Install darwin repository",
-          "subSection1Paragraph1": "osquery can be installed from the Homebrew Cask repository.",
-          "terminalCommands": [
-            "brew install --cask osquery"
+          "sections": [
+            {
+              "heading": "Install darwin repository",
+              "paragraph": "osquery can be installed from the Homebrew Cask repository",
+              "terminalCommands": [
+                "brew install --cask osquery"
+              ]
+            }
           ]
         },
         "ubuntu": {
-          "subSection1Heading": "Install apt repository",
-          "subSection1Paragraph1": "We publish osquery to an apt repository. The DEBs have extremely few dependencies and should work on *most* x86_64 Linux operating systems.",
-          "terminalCommands": [
-            "sudo mkdir -p /etc/apt/keyrings",
-            "curl -L https://pkg.osquery.io/deb/pubkey.gpg | sudo tee /etc/apt/keyrings/osquery.asc",
-            "sudo add-apt-repository 'deb [arch=amd64 signed-by=/etc/apt/keyrings/osquery.asc] https://pkg.osquery.io/deb deb main'",
-            "sudo apt install osquery"
+          "sections": [
+            {
+              "heading": "Install apt repository",
+              "paragraph": "We publish osquery to an apt repository. The DEBs have extremely few dependencies and should work on *most* x86_64 Linux operating systems.",
+              "terminalCommands": [
+                "sudo mkdir -p /etc/apt/keyrings",
+                "curl -L https://pkg.osquery.io/deb/pubkey.gpg | sudo tee /etc/apt/keyrings/osquery.asc",
+                "sudo add-apt-repository 'deb [arch=amd64 signed-by=/etc/apt/keyrings/osquery.asc] https://pkg.osquery.io/deb deb main'",
+                "sudo apt install osquery"
+              ]
+            }
           ]
         },
         "centos": {
-          "subSection1Heading": "Install yum repository",
-          "subSection1Paragraph1": "We publish osquery to a yum repository. The RPMs have extremely few dependencies and should work on *most* x86_64 Linux operating systems. You may install the \"auto-repo-add\" RPM or add the repository target.",
-          "terminalCommands": [
-            "curl -L https://pkg.osquery.io/rpm/GPG | sudo tee /etc/pki/rpm-gpg/RPM-GPG-KEY-osquery",
-            "sudo yum-config-manager --add-repo https://pkg.osquery.io/rpm/osquery-s3-rpm.repo",
-            "sudo yum-config-manager --enable osquery-s3-rpm-repo",
-            "sudo yum install osquery"
+          "sections": [
+            {
+              "heading": "Install yum repository",
+              "paragraph": "We publish osquery to a yum repository. The RPMs have extremely few dependencies and should work on *most* x86_64 Linux operating systems. You may install the \"auto-repo-add\" RPM or add the repository target.",
+              "terminalCommands": [
+                "curl -L https://pkg.osquery.io/rpm/GPG | sudo tee /etc/pki/rpm-gpg/RPM-GPG-KEY-osquery",
+                "sudo yum-config-manager --add-repo https://pkg.osquery.io/rpm/osquery-s3-rpm.repo",
+                "sudo yum-config-manager --enable osquery-s3-rpm-repo",
+                "sudo yum install osquery"
+              ]
+            }
           ]
         },
         "windows": {
-          "subSection1Heading": "Install windows repository",
-          "subSection1Paragraph1": "We recommend installing and deploying Windows support using chocolatey. Please let us know if your enterprise could make use of other package formats.",
-          "terminalCommands": [
-            "choco install osquery"
+          "sections": [
+            {
+              "heading": "arm64/aarch64 windows support",
+              "paragraph": "Though there is not currently an msi install available, you can find the windows arm64 build on the GitHub releases page -- https://github.com/osquery/osquery/releases",
+              "terminalCommands": []
+            },
+            {
+              "heading": "Additional Install windows repository",
+              "paragraph": "We recommend installing and deploying Windows support using chocolatey. Please let us know if your enterprise could make use of other package formats.",
+              "terminalCommands": [
+                "choco install osquery"
+              ]
+            }
           ]
         }
       }

--- a/src/data/pages/downloads.json
+++ b/src/data/pages/downloads.json
@@ -24,13 +24,24 @@
         "ubuntu": {
           "sections": [
             {
-              "heading": "Install apt repository",
+              "heading": "Install apt repository (22.04 and later)",
               "paragraph": "We publish osquery to an apt repository. The DEBs have extremely few dependencies and should work on *most* x86_64 Linux operating systems.",
               "terminalCommands": [
                 "sudo mkdir -p /etc/apt/keyrings",
                 "curl -L https://pkg.osquery.io/deb/pubkey.gpg | sudo tee /etc/apt/keyrings/osquery.asc",
                 "sudo add-apt-repository 'deb [arch=amd64 signed-by=/etc/apt/keyrings/osquery.asc] https://pkg.osquery.io/deb deb main'",
                 "sudo apt install osquery"
+              ]
+            },
+            {
+              "heading": "Install apt repository (Prior to 22.04)",
+              "paragraph": "This uses apt-key",
+              "terminalCommands": [
+                "export OSQUERY_KEY=1484120AC4E9F8A1A577AEEE97A80C63C9D8B80B",
+                "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys $OSQUERY_KEY",
+                "sudo add-apt-repository 'deb [arch=amd64] https://pkg.osquery.io/deb deb main'",
+                "sudo apt-get update",
+                "sudo apt-get install osquery"
               ]
             }
           ]
@@ -53,7 +64,7 @@
           "sections": [
             {
               "heading": "arm64/aarch64 windows support",
-              "paragraph": "Though there is not currently an msi install available, you can find the windows arm64 build on the GitHub releases page -- https://github.com/osquery/osquery/releases",
+              "paragraph": "Though there is not currently an msi install available, you can find the windows arm64 build on the GitHub releases page (https://github.com/osquery/osquery/releases)",
               "terminalCommands": []
             },
             {

--- a/src/pages/Downloads/Downloads.js
+++ b/src/pages/Downloads/Downloads.js
@@ -155,24 +155,28 @@ class Downloads extends Component {
             name={selectedInstallOption}
           />
 
-          <div>
-            <Heading5>{alternativeInstallOptionContent.subSection1Heading}</Heading5>
-
-            <Paragraph>{alternativeInstallOptionContent.subSection1Paragraph1}</Paragraph>
-          </div>
-
-          <Terminal.Wrapper className={`${baseClass}__terminal`}>
-            <Terminal.Body className={`${baseClass}__terminal-body`}>
-              {alternativeInstallOptionContent.terminalCommands.map((terminalCommand, idx) => {
-                return (
-                  <Monospace key={`terminal-command-${idx}`}>
-                    <label className="unselectable">$</label> {terminalCommand}
-                    <br />
-                  </Monospace>
-                )
-              })}
-            </Terminal.Body>
-          </Terminal.Wrapper>
+          {alternativeInstallOptionContent.sections.map((sec, idx) => {
+            return (
+              <div>
+                <Heading5>{sec.heading}</Heading5>
+                <Paragraph>{sec.paragraph}</Paragraph>
+                {sec.terminalCommands.length > 0 && (
+                  <Terminal.Wrapper className={`${baseClass}__terminal`}>
+                    <Terminal.Body className={`${baseClass}__terminal-body`}>
+                      {sec.terminalCommands.map((terminalCommand, idx) => {
+                        return (
+                          <Monospace key={`terminal-command-${idx}`}>
+                            <label className="unselectable">$</label> {terminalCommand}
+                            <br />
+                          </Monospace>
+                        )
+                      })}
+                    </Terminal.Body>
+                  </Terminal.Wrapper>
+                )}
+              </div>
+            )
+          })}
         </section>
       </div>
     )

--- a/src/pages/Downloads/Downloads.js
+++ b/src/pages/Downloads/Downloads.js
@@ -22,17 +22,17 @@ const OFFICIAL = 'official'
 
 const baseClass = 'downloads-page'
 const installOptionNames = {
+  windows: 'Windows',
   darwin: 'macOS',
   ubuntu: 'Debian Linux',
   centos: 'RPM Linux',
-  windows: 'Windows',
 }
 const installOptionNamesKeys = keys(installOptionNames)
 const installOptionNamesValues = values(installOptionNames)
 
 class Downloads extends Component {
   state = {
-    selectedInstallOption: 'darwin',
+    selectedInstallOption: 'windows',
   }
 
   onInstallOptionChange = installOption => {


### PR DESCRIPTION
I'm not convinced I love this, but it's the best I can do with the framework here...

We have two things we need to change in the alternate downloads.

First, we don't mention windows arm. This feels a little awkward -- we don't have an MSI, so it feels weird to add a tile for it. So I added it to the alternates below. (Fixes #284)

Second, people on older ubuntu/debian machines, need the older dpkg instructions -- the ones based on `apt-key`. (Relates to #275)

I spent some time tinkering with this code. And thought the simplest thing would be to replace the `subSection1Heading` and `subSection1Paragraph1` with an array of heading/paragraph/terminal objects. I don't love the rendering, but I'm not sure it's _worse_...
<img width="1737" alt="Screenshot 2023-10-24 at 00 24 51" src="https://github.com/osquery/osquery-site/assets/179542/9233d3da-cfe1-4e8f-9852-4c7a7a303fbf">
<img width="1737" alt="Screenshot 2023-10-24 at 00 25 02" src="https://github.com/osquery/osquery-site/assets/179542/38c837bf-2df1-46bd-ab80-ebb9bf1fa72b">

